### PR TITLE
Fix Mermaid diagram syntax in architecture documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,21 +9,17 @@ flowchart LR
   end
 
   subgraph App[Flask Application]
-    WEB[Flask Web
-    - books/config/exports views]
-    CORE[(core/ parser
-    + collector)]
+    WEB[Flask Web<br/>books/config/exports views]
+    CORE[(core/ parser<br/>+ collector)]
   end
 
   subgraph Worker[Background]
-    CELERY[Celery Worker
-    - scan & export tasks]
+    CELERY[Celery Worker<br/>scan & export tasks]
   end
 
-  DB[(Postgres
-  + Image Blobs)]
+  DB[(Postgres<br/>Image Blobs)]
   MQ[(RabbitMQ)]
-  FS[/Source Folders<br/>sample-highlights devices/]
+  FS[/Source Folders<br/>read-only/]
   EXPORTS[/Export Files<br/>ZIP archives/]
   OL[(Open Library API)]
 
@@ -38,12 +34,6 @@ flowchart LR
   WEB -->|HTTP fetch images| OL
   CELERY -->|write ZIP files| EXPORTS
   WEB -->|serve downloads| EXPORTS
-
-  note right of FS
-    metadata.*.lua files
-    per device folders
-    read-only mount
-  end
 
   classDef store fill:#eef,stroke:#99c
   classDef ext fill:#ffe,stroke:#cc9


### PR DESCRIPTION
## Summary

Fixes syntax errors in the Mermaid flowchart diagram in `docs/ARCHITECTURE.md` that were preventing proper rendering.

## Changes

- Removed unsupported `note` block (not valid in flowchart syntax)
- Fixed label formatting to use `<br/>` instead of newlines within node definitions
- Simplified node labels to avoid parsing issues
- Validated diagram locally using `@mermaid-js/mermaid-cli` before committing

## Testing

```bash
# Installed mermaid-cli
npm install -g @mermaid-js/mermaid-cli

# Tested diagram locally
mmdc -i /tmp/test-diagram.mmd -o /tmp/test-diagram.svg
# ✅ Successfully generated SVG without errors
```

## Result

The architecture diagram now renders correctly showing the complete system flow including:
- Client (browser) → Flask web app
- Flask → PostgreSQL (images) + RabbitMQ (task queue)
- Celery worker → Source folders (read-only scan)
- Celery → Export files (ZIP generation)
- Flask → Export downloads

Related to #2 (Export feature PR)