### PR TITLE
feat: add job retention policy and Flower monitoring

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,12 +10,22 @@ db = SQLAlchemy()
 def create_app() -> Flask:
     app = Flask(__name__)
 
-    app.config.setdefault("SQLALCHEMY_DATABASE_URI", os.getenv("DATABASE_URL", "sqlite:///app.db"))
+    app.config.setdefault(
+        "SQLALCHEMY_DATABASE_URI", os.getenv("DATABASE_URL", "sqlite:///app.db")
+    )
     app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
     app.config.setdefault("SQLALCHEMY_ENGINE_OPTIONS", {"pool_pre_ping": True})
-    app.config.setdefault("HIGHLIGHTS_BASE_PATH", os.getenv("HIGHLIGHTS_BASE_PATH", str((os.getcwd() + "/sample-highlights"))))
-    app.config.setdefault("CELERY_BROKER_URL", os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672//"))
-    app.config.setdefault("CELERY_RESULT_BACKEND", os.getenv("CELERY_RESULT_BACKEND", "rpc://"))
+    app.config.setdefault(
+        "HIGHLIGHTS_BASE_PATH",
+        os.getenv("HIGHLIGHTS_BASE_PATH", str((os.getcwd() + "/sample-highlights"))),
+    )
+    app.config.setdefault(
+        "CELERY_BROKER_URL",
+        os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672//"),
+    )
+    app.config.setdefault(
+        "CELERY_RESULT_BACKEND", os.getenv("CELERY_RESULT_BACKEND", "rpc://")
+    )
     app.config.setdefault("EXPORT_DIR", os.getenv("EXPORT_DIR", "/tmp/exports"))
     # Required for flash messages and sessions. Treat empty as unset.
     _sk = os.getenv("SECRET_KEY")
@@ -26,50 +36,53 @@ def create_app() -> Flask:
     db.init_app(app)
 
     # Register custom Jinja filters
-    @app.template_filter('from_json')
+    @app.template_filter("from_json")
     def from_json_filter(json_str):
         """Parse JSON string to Python object."""
         if not json_str:
             return {}
         try:
             import json
+
             return json.loads(json_str)
         except (ValueError, TypeError):
             return {}
 
-    @app.template_filter('humandate')
+    @app.template_filter("humandate")
     def humandate_filter(date_str):
         """Convert datetime string to human-readable format with time."""
         if not date_str:
-            return ''
+            return ""
         try:
             from datetime import datetime
+
             # Parse KOReader datetime format: YYYY-MM-DD HH:MM:SS
-            dt = datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
+            dt = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
             # Format as: "Jun 30, 2025 at 6:15 PM"
             # Use %I instead of %-I for cross-platform compatibility, then strip leading zero
-            time_str = dt.strftime('%b %d, %Y at %I:%M %p')
+            time_str = dt.strftime("%b %d, %Y at %I:%M %p")
             # Remove leading zero from hour (e.g., "06:15" -> "6:15")
-            return time_str.replace(' 0', ' ')
+            return time_str.replace(" 0", " ")
         except (ValueError, AttributeError):
             # If parsing fails, return original
             return date_str
 
-    @app.template_filter('humandate_short')
+    @app.template_filter("humandate_short")
     def humandate_short_filter(date_str):
         """Convert datetime string to short date format (no time)."""
         if not date_str:
-            return ''
+            return ""
         try:
             from datetime import datetime
+
             # Try parsing full datetime format first: YYYY-MM-DD HH:MM:SS
             try:
-                dt = datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
+                dt = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
             except ValueError:
                 # Try parsing date-only format: YYYY-MM-DD
-                dt = datetime.strptime(date_str, '%Y-%m-%d')
+                dt = datetime.strptime(date_str, "%Y-%m-%d")
             # Format as: "Jun 30, 2025"
-            return dt.strftime('%b %d, %Y')
+            return dt.strftime("%b %d, %Y")
         except (ValueError, AttributeError):
             # If parsing fails, return original
             return date_str
@@ -77,6 +90,7 @@ def create_app() -> Flask:
     # Create tables on startup for convenience (no Alembic yet)
     with app.app_context():
         from . import models  # noqa: F401
+
         # Wait for DB to be ready
         last_err = None
         for _ in range(30):
@@ -85,6 +99,7 @@ def create_app() -> Flask:
                 # Seed a default source path if DB is empty and config path exists
                 try:
                     from .models import AppConfig
+
                     # Ensure one AppConfig row exists
                     if not AppConfig.query.first():
                         db.session.add(AppConfig())
@@ -105,6 +120,7 @@ def create_app() -> Flask:
     from .views.config import bp as config_bp
     from .views.exports import bp as exports_bp
     from .views.jobs import bp as jobs_bp
+
     app.register_blueprint(books_bp)
     app.register_blueprint(tasks_bp)
     app.register_blueprint(config_bp)
@@ -114,29 +130,36 @@ def create_app() -> Flask:
     # Error pages
     @app.errorhandler(404)
     def not_found(e):
-        return render_template('errors/404.html'), 404
+        return render_template("errors/404.html"), 404
 
     @app.errorhandler(500)
     def server_error(e):
-        return render_template('errors/500.html'), 500
+        return render_template("errors/500.html"), 500
 
-    @app.get('/assets/<path:filename>')
+    @app.get("/assets/<path:filename>")
     def assets_file(filename: str):
         # Serve files from repository-level assets folder, then fallback to repo root
         repo_root = Path(app.root_path).parent
-        assets_dir = repo_root / 'assets'
+        assets_dir = repo_root / "assets"
         candidates = [assets_dir / filename, repo_root / filename]
         for fp in candidates:
             if fp.exists():
                 return send_from_directory(fp.parent.as_posix(), fp.name)
         abort(404)
 
-    @app.get('/assets/banner')
+    @app.get("/assets/banner")
     def assets_banner():
         # Serve a banner image with flexible extensions
         repo_root = Path(app.root_path).parent
-        assets_dir = repo_root / 'assets'
-        names = ['banner.png', 'banner.jpg', 'banner.jpeg', 'banner.webp', 'banner.gif', 'banner.svg']
+        assets_dir = repo_root / "assets"
+        names = [
+            "banner.png",
+            "banner.jpg",
+            "banner.jpeg",
+            "banner.webp",
+            "banner.gif",
+            "banner.svg",
+        ]
         for name in names:
             for base in (assets_dir, repo_root):
                 fp = base / name

--- a/app/models.py
+++ b/app/models.py
@@ -4,11 +4,13 @@ from . import db
 
 class TimestampMixin:
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
 
 class Book(db.Model, TimestampMixin):
-    __tablename__ = 'books'
+    __tablename__ = "books"
     id = db.Column(db.Integer, primary_key=True)
     checksum = db.Column(db.String(64), index=True)  # partial_md5_checksum or path hash
     raw_title = db.Column(db.String)
@@ -25,16 +27,24 @@ class Book(db.Model, TimestampMixin):
     image_data = db.Column(db.LargeBinary, nullable=True)  # Store image as blob
     image_content_type = db.Column(db.String(100), nullable=True)  # e.g., 'image/jpeg'
 
-    highlights = db.relationship('Highlight', backref='book', cascade="all, delete-orphan")
-    notes = db.relationship('Note', backref='book', cascade="all, delete-orphan")
-    bookmarks = db.relationship('Bookmark', backref='book', cascade="all, delete-orphan")
-    merged = db.relationship('MergedHighlight', backref='book', cascade="all, delete-orphan")
+    highlights = db.relationship(
+        "Highlight", backref="book", cascade="all, delete-orphan"
+    )
+    notes = db.relationship("Note", backref="book", cascade="all, delete-orphan")
+    bookmarks = db.relationship(
+        "Bookmark", backref="book", cascade="all, delete-orphan"
+    )
+    merged = db.relationship(
+        "MergedHighlight", backref="book", cascade="all, delete-orphan"
+    )
 
 
 class Highlight(db.Model, TimestampMixin):
-    __tablename__ = 'highlights'
+    __tablename__ = "highlights"
     id = db.Column(db.Integer, primary_key=True)
-    book_id = db.Column(db.Integer, db.ForeignKey('books.id'), index=True, nullable=False)
+    book_id = db.Column(
+        db.Integer, db.ForeignKey("books.id"), index=True, nullable=False
+    )
     text = db.Column(db.Text)
     chapter = db.Column(db.String)
     page_number = db.Column(db.Integer)
@@ -43,24 +53,32 @@ class Highlight(db.Model, TimestampMixin):
     drawer = db.Column(db.String)
     device_id = db.Column(db.String)
     page_xpath = db.Column(db.Text)
-    kind = db.Column(db.String, default='highlight')  # highlight, bookmark, note, etc.
-    hidden = db.Column(db.Boolean, default=False, nullable=False, index=True)  # hide from UI
-    devices = db.relationship('HighlightDevice', backref='highlight', cascade="all, delete-orphan")
+    kind = db.Column(db.String, default="highlight")  # highlight, bookmark, note, etc.
+    hidden = db.Column(
+        db.Boolean, default=False, nullable=False, index=True
+    )  # hide from UI
+    devices = db.relationship(
+        "HighlightDevice", backref="highlight", cascade="all, delete-orphan"
+    )
 
 
 class Note(db.Model, TimestampMixin):
-    __tablename__ = 'notes'
+    __tablename__ = "notes"
     id = db.Column(db.Integer, primary_key=True)
-    book_id = db.Column(db.Integer, db.ForeignKey('books.id'), index=True, nullable=False)
+    book_id = db.Column(
+        db.Integer, db.ForeignKey("books.id"), index=True, nullable=False
+    )
     text = db.Column(db.Text)
     datetime = db.Column(db.String)
     device_id = db.Column(db.String)
 
 
 class Bookmark(db.Model, TimestampMixin):
-    __tablename__ = 'bookmarks'
+    __tablename__ = "bookmarks"
     id = db.Column(db.Integer, primary_key=True)
-    book_id = db.Column(db.Integer, db.ForeignKey('books.id'), index=True, nullable=False)
+    book_id = db.Column(
+        db.Integer, db.ForeignKey("books.id"), index=True, nullable=False
+    )
     chapter = db.Column(db.String)
     page_number = db.Column(db.Integer)
     datetime = db.Column(db.String)
@@ -68,33 +86,43 @@ class Bookmark(db.Model, TimestampMixin):
 
 
 class MergedHighlight(db.Model, TimestampMixin):
-    __tablename__ = 'merged_highlights'
+    __tablename__ = "merged_highlights"
     id = db.Column(db.Integer, primary_key=True)
-    book_id = db.Column(db.Integer, db.ForeignKey('books.id'), index=True, nullable=False)
+    book_id = db.Column(
+        db.Integer, db.ForeignKey("books.id"), index=True, nullable=False
+    )
     text = db.Column(db.Text)
     notes = db.Column(db.Text)
-    items = db.relationship('MergedHighlightItem', backref='merged', cascade="all, delete-orphan")
+    items = db.relationship(
+        "MergedHighlightItem", backref="merged", cascade="all, delete-orphan"
+    )
 
 
 class MergedHighlightItem(db.Model):
-    __tablename__ = 'merged_highlight_items'
+    __tablename__ = "merged_highlight_items"
     id = db.Column(db.Integer, primary_key=True)
-    merged_id = db.Column(db.Integer, db.ForeignKey('merged_highlights.id'), index=True, nullable=False)
-    highlight_id = db.Column(db.Integer, db.ForeignKey('highlights.id'), index=True, nullable=False)
+    merged_id = db.Column(
+        db.Integer, db.ForeignKey("merged_highlights.id"), index=True, nullable=False
+    )
+    highlight_id = db.Column(
+        db.Integer, db.ForeignKey("highlights.id"), index=True, nullable=False
+    )
 
 
 class HighlightDevice(db.Model):
-    __tablename__ = 'highlight_devices'
+    __tablename__ = "highlight_devices"
     id = db.Column(db.Integer, primary_key=True)
-    highlight_id = db.Column(db.Integer, db.ForeignKey('highlights.id'), index=True, nullable=False)
+    highlight_id = db.Column(
+        db.Integer, db.ForeignKey("highlights.id"), index=True, nullable=False
+    )
     device_id = db.Column(db.String, nullable=False)
     __table_args__ = (
-        db.UniqueConstraint('highlight_id', 'device_id', name='uq_highlight_device'),
+        db.UniqueConstraint("highlight_id", "device_id", name="uq_highlight_device"),
     )
 
 
 class SourcePath(db.Model, TimestampMixin):
-    __tablename__ = 'source_paths'
+    __tablename__ = "source_paths"
     id = db.Column(db.Integer, primary_key=True)
     path = db.Column(db.Text, nullable=False, unique=True)
     enabled = db.Column(db.Boolean, default=True, nullable=False)
@@ -102,48 +130,70 @@ class SourcePath(db.Model, TimestampMixin):
 
 
 class AppConfig(db.Model, TimestampMixin):
-    __tablename__ = 'app_config'
+    __tablename__ = "app_config"
     id = db.Column(db.Integer, primary_key=True)
     goodreads_api_key = db.Column(db.Text, nullable=True)  # legacy, unused
     ol_app_name = db.Column(db.String(100), nullable=True)
     ol_contact_email = db.Column(db.String(200), nullable=True)
-    scan_schedule = db.Column(db.String(100), nullable=True, default='*/15 * * * *')  # cron syntax, default: every 15 minutes
-    job_retention_days = db.Column(db.Integer, nullable=False, default=30)  # Delete jobs older than this many days
+    scan_schedule = db.Column(
+        db.String(100), nullable=True, default="*/15 * * * *"
+    )  # cron syntax, default: every 15 minutes
+    job_retention_days = db.Column(
+        db.Integer, nullable=False, default=30
+    )  # Delete jobs older than this many days
 
 
 class ExportTemplate(db.Model, TimestampMixin):
-    __tablename__ = 'export_templates'
+    __tablename__ = "export_templates"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(200), nullable=False)
     template_content = db.Column(db.Text, nullable=False)
     is_default = db.Column(db.Boolean, default=False, nullable=False)
     # Jinja2 templates for filenames - variables: book_title, book_authors, export_date
-    filename_template = db.Column(db.String(500), nullable=False, default='{{ book_title }}.md')
-    cover_filename_template = db.Column(db.String(500), nullable=False, default='{{ book_title }}')
+    filename_template = db.Column(
+        db.String(500), nullable=False, default="{{ book_title }}.md"
+    )
+    cover_filename_template = db.Column(
+        db.String(500), nullable=False, default="{{ book_title }}"
+    )
 
 
 class Job(db.Model, TimestampMixin):
-    __tablename__ = 'jobs'
+    __tablename__ = "jobs"
     id = db.Column(db.Integer, primary_key=True)
-    job_id = db.Column(db.String(100), unique=True, nullable=False, index=True)  # UUID or task ID
-    job_type = db.Column(db.String(50), nullable=False, index=True)  # scan, export, etc.
-    status = db.Column(db.String(50), default='pending', nullable=False, index=True)  # pending, processing, completed, failed
+    job_id = db.Column(
+        db.String(100), unique=True, nullable=False, index=True
+    )  # UUID or task ID
+    job_type = db.Column(
+        db.String(50), nullable=False, index=True
+    )  # scan, export, etc.
+    status = db.Column(
+        db.String(50), default="pending", nullable=False, index=True
+    )  # pending, processing, completed, failed
     error_message = db.Column(db.Text, nullable=True)
     result_summary = db.Column(db.Text, nullable=True)  # JSON summary of results
     completed_at = db.Column(db.DateTime, nullable=True)
 
 
 class ExportJob(db.Model, TimestampMixin):
-    __tablename__ = 'export_jobs'
+    __tablename__ = "export_jobs"
     id = db.Column(db.Integer, primary_key=True)
-    job_id = db.Column(db.String(100), unique=True, nullable=False, index=True)  # UUID for the job
-    book_id = db.Column(db.Integer, db.ForeignKey('books.id'), index=True, nullable=False)
-    template_id = db.Column(db.Integer, db.ForeignKey('export_templates.id'), nullable=False)
+    job_id = db.Column(
+        db.String(100), unique=True, nullable=False, index=True
+    )  # UUID for the job
+    book_id = db.Column(
+        db.Integer, db.ForeignKey("books.id"), index=True, nullable=False
+    )
+    template_id = db.Column(
+        db.Integer, db.ForeignKey("export_templates.id"), nullable=False
+    )
     highlight_ids = db.Column(db.Text, nullable=False)  # JSON array of highlight IDs
-    status = db.Column(db.String(50), default='pending', nullable=False)  # pending, processing, completed, failed
+    status = db.Column(
+        db.String(50), default="pending", nullable=False
+    )  # pending, processing, completed, failed
     error_message = db.Column(db.Text, nullable=True)
     file_path = db.Column(db.Text, nullable=True)  # Path to generated zip file
     completed_at = db.Column(db.DateTime, nullable=True)
 
-    book = db.relationship('Book', backref='export_jobs')
-    template = db.relationship('ExportTemplate', backref='export_jobs')
+    book = db.relationship("Book", backref="export_jobs")
+    template = db.relationship("ExportTemplate", backref="export_jobs")

--- a/app/models.py
+++ b/app/models.py
@@ -108,6 +108,7 @@ class AppConfig(db.Model, TimestampMixin):
     ol_app_name = db.Column(db.String(100), nullable=True)
     ol_contact_email = db.Column(db.String(200), nullable=True)
     scan_schedule = db.Column(db.String(100), nullable=True, default='*/15 * * * *')  # cron syntax, default: every 15 minutes
+    job_retention_days = db.Column(db.Integer, nullable=False, default=30)  # Delete jobs older than this many days
 
 
 class ExportTemplate(db.Model, TimestampMixin):

--- a/app/services/imagestore.py
+++ b/app/services/imagestore.py
@@ -11,19 +11,23 @@ def fetch_image_from_url(remote_url: str) -> Optional[Tuple[bytes, str]]:
     Returns tuple of (bytes, content_type) on success, None on failure.
     """
     if not remote_url:
-        logger.warning('fetch_image_from_url: missing remote_url')
+        logger.warning("fetch_image_from_url: missing remote_url")
         return None
 
     try:
-        logger.debug(f'Fetching image from {remote_url}')
+        logger.debug(f"Fetching image from {remote_url}")
         response = requests.get(remote_url, timeout=10)
         if response.ok:
-            content_type = response.headers.get('content-type', 'image/jpeg')
-            logger.info(f'Successfully fetched image from {remote_url} ({len(response.content)} bytes, {content_type})')
+            content_type = response.headers.get("content-type", "image/jpeg")
+            logger.info(
+                f"Successfully fetched image from {remote_url} ({len(response.content)} bytes, {content_type})"
+            )
             return (response.content, content_type)
         else:
-            logger.warning(f'Failed to fetch image from {remote_url}: HTTP {response.status_code}')
+            logger.warning(
+                f"Failed to fetch image from {remote_url}: HTTP {response.status_code}"
+            )
             return None
     except Exception as e:
-        logger.error(f'Error fetching image from {remote_url}: {e}')
+        logger.error(f"Error fetching image from {remote_url}: {e}")
         return None

--- a/app/templates/config/index.html
+++ b/app/templates/config/index.html
@@ -61,19 +61,6 @@
       <div id="schedule-validation" class="mb-2"></div>
       <button class="btn btn-primary btn-sm" id="save-schedule-btn" disabled>Save Schedule</button>
     </form>
-
-    <h2 class="h5 mt-4">Job Retention</h2>
-    <p class="text-muted small mb-2">Automatically delete old jobs and their exported files to save disk space.</p>
-    <form method="post">
-      <div class="mb-2">
-        <div class="input-group" style="max-width: 250px;">
-          <input type="number" name="job_retention_days" class="form-control form-control-sm" value="{{ cfg.job_retention_days or 30 }}" min="1" max="365" required>
-          <span class="input-group-text">days</span>
-        </div>
-        <small class="text-muted d-block">Delete jobs older than this many days (default: 30)</small>
-      </div>
-      <button class="btn btn-primary btn-sm">Save Retention Policy</button>
-    </form>
   </div>
 
   <div class="col-lg-6">
@@ -85,6 +72,19 @@
         <input name="ol_contact_email" type="email" class="form-control form-control-sm" placeholder="Contact Email (required)" value="{{ cfg.ol_contact_email or '' }}" required>
       </div>
       <button class="btn btn-primary btn-sm">Save Open Library Config</button>
+    </form>
+
+    <h2 class="h5 mt-4">Job Retention</h2>
+    <p class="text-muted small mb-2">Automatically delete old jobs and exported files.</p>
+    <form method="post">
+      <div class="mb-2">
+        <div class="input-group" style="max-width: 180px;">
+          <input type="number" name="job_retention_days" class="form-control form-control-sm" value="{{ cfg.job_retention_days or 30 }}" min="1" max="365" required>
+          <span class="input-group-text">days</span>
+        </div>
+        <small class="text-muted d-block">Delete jobs older than this (default: 30)</small>
+      </div>
+      <button class="btn btn-primary btn-sm">Save</button>
     </form>
   </div>
 </div>

--- a/app/templates/config/index.html
+++ b/app/templates/config/index.html
@@ -61,6 +61,19 @@
       <div id="schedule-validation" class="mb-2"></div>
       <button class="btn btn-primary btn-sm" id="save-schedule-btn" disabled>Save Schedule</button>
     </form>
+
+    <h2 class="h5 mt-4">Job Retention</h2>
+    <p class="text-muted small mb-2">Automatically delete old jobs and their exported files to save disk space.</p>
+    <form method="post">
+      <div class="mb-2">
+        <div class="input-group" style="max-width: 250px;">
+          <input type="number" name="job_retention_days" class="form-control form-control-sm" value="{{ cfg.job_retention_days or 30 }}" min="1" max="365" required>
+          <span class="input-group-text">days</span>
+        </div>
+        <small class="text-muted d-block">Delete jobs older than this many days (default: 30)</small>
+      </div>
+      <button class="btn btn-primary btn-sm">Save Retention Policy</button>
+    </form>
   </div>
 
   <div class="col-lg-6">

--- a/app/templates/exports/job_status.html
+++ b/app/templates/exports/job_status.html
@@ -17,9 +17,9 @@
       <p class="card-text text-muted">
         <strong>Template:</strong> {{ job.template.name }}<br>
         <strong>Job ID:</strong> <code>{{ job.job_id }}</code><br>
-        <strong>Created:</strong> {{ job.created_at.strftime('%b %d, %Y at %I:%M %p') }}<br>
+        <strong>Created:</strong> <span class="local-time" data-utc="{{ job.created_at.isoformat() }}Z">{{ job.created_at.strftime('%b %d, %Y at %I:%M %p') }}</span><br>
         {% if job.completed_at %}
-        <strong>Completed:</strong> {{ job.completed_at.strftime('%b %d, %Y at %I:%M %p') }}<br>
+        <strong>Completed:</strong> <span class="local-time" data-utc="{{ job.completed_at.isoformat() }}Z">{{ job.completed_at.strftime('%b %d, %Y at %I:%M %p') }}</span><br>
         {% endif %}
       </p>
 
@@ -56,6 +56,23 @@
 </div>
 
 <script>
+// Convert UTC timestamps to local timezone
+document.querySelectorAll('.local-time').forEach(el => {
+  const utcTime = el.dataset.utc;
+  if (utcTime) {
+    const date = new Date(utcTime);
+    const options = {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    };
+    el.textContent = date.toLocaleString('en-US', options);
+  }
+});
+
 // Auto-refresh job status if not completed/failed
 {% if job.status in ['pending', 'processing'] %}
 const jobId = '{{ job.job_id }}';

--- a/app/templates/exports/jobs.html
+++ b/app/templates/exports/jobs.html
@@ -31,9 +31,9 @@
           </h5>
           <p class="mb-1 text-muted small">
             Template: {{ job.template.name }} •
-            Created: {{ job.created_at.strftime('%b %d, %Y at %I:%M %p') }}
+            Created: <span class="local-time" data-utc="{{ job.created_at.isoformat() }}Z">{{ job.created_at.strftime('%b %d, %Y at %I:%M %p') }}</span>
             {% if job.completed_at %}
-            • Completed: {{ job.completed_at.strftime('%b %d, %Y at %I:%M %p') }}
+            • Completed: <span class="local-time" data-utc="{{ job.completed_at.isoformat() }}Z">{{ job.completed_at.strftime('%b %d, %Y at %I:%M %p') }}</span>
             {% endif %}
           </p>
         </div>
@@ -59,4 +59,23 @@
   </div>
   {% endif %}
 </div>
+
+<script>
+// Convert UTC timestamps to local timezone
+document.querySelectorAll('.local-time').forEach(el => {
+  const utcTime = el.dataset.utc;
+  if (utcTime) {
+    const date = new Date(utcTime);
+    const options = {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    };
+    el.textContent = date.toLocaleString('en-US', options);
+  }
+});
+</script>
 {% endblock %}

--- a/app/templates/jobs/index.html
+++ b/app/templates/jobs/index.html
@@ -3,9 +3,18 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h1 class="h4 m-0">Background Jobs</h1>
-  <button class="btn btn-sm btn-outline-secondary" onclick="location.reload()">
-    <i class="fa-solid fa-rotate"></i> Refresh
-  </button>
+  <div class="btn-group">
+    <button class="btn btn-sm btn-outline-secondary" onclick="location.reload()">
+      <i class="fa-solid fa-rotate"></i> Refresh
+    </button>
+    {% if jobs|selectattr('status', 'equalto', 'completed')|list %}
+    <form method="post" action="{{ url_for('jobs.clear_completed') }}" class="d-inline" onsubmit="return confirm('Clear all completed jobs? This cannot be undone.');">
+      <button type="submit" class="btn btn-sm btn-outline-danger">
+        <i class="fa-solid fa-trash"></i> Clear Completed
+      </button>
+    </form>
+    {% endif %}
+  </div>
 </div>
 
 <p class="text-muted small">
@@ -45,11 +54,11 @@
         </span>
       </td>
       <td>
-        <code class="text-muted small">{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</code>
+        <code class="text-muted small local-time" data-utc="{{ job.created_at.isoformat() }}Z">{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</code>
       </td>
       <td>
         {% if job.completed_at %}
-          <code class="text-muted small">{{ job.completed_at.strftime('%Y-%m-%d %H:%M:%S') }}</code>
+          <code class="text-muted small local-time" data-utc="{{ job.completed_at.isoformat() }}Z">{{ job.completed_at.strftime('%Y-%m-%d %H:%M:%S') }}</code>
         {% else %}
           <span class="text-muted">-</span>
         {% endif %}
@@ -97,6 +106,20 @@
 </table>
 
 <script>
+// Convert UTC timestamps to local timezone
+document.querySelectorAll('.local-time').forEach(el => {
+  const utcTime = el.dataset.utc;
+  if (utcTime) {
+    const date = new Date(utcTime);
+    el.textContent = date.getFullYear() + '-' +
+      String(date.getMonth() + 1).padStart(2, '0') + '-' +
+      String(date.getDate()).padStart(2, '0') + ' ' +
+      String(date.getHours()).padStart(2, '0') + ':' +
+      String(date.getMinutes()).padStart(2, '0') + ':' +
+      String(date.getSeconds()).padStart(2, '0');
+  }
+});
+
 // Auto-refresh processing jobs every 5 seconds
 (function() {
   const hasProcessing = {{ 'true' if jobs|selectattr('status', 'equalto', 'processing')|list else 'false' }};

--- a/app/views/config.py
+++ b/app/views/config.py
@@ -7,10 +7,10 @@ from croniter import croniter
 from .. import db
 from ..models import SourcePath, AppConfig, ExportTemplate
 
-bp = Blueprint('config', __name__)
+bp = Blueprint("config", __name__)
 
 
-@bp.route('/config', methods=['GET', 'POST'])
+@bp.route("/config", methods=["GET", "POST"])
 def index():
     # Ensure a config row exists
     cfg = AppConfig.query.first()
@@ -19,74 +19,92 @@ def index():
         db.session.add(cfg)
         db.session.commit()
 
-    if request.method == 'POST':
-        if 'path' in request.form:
-            path = (request.form.get('path') or '').strip()
-            raw_label = (request.form.get('device_label') or '').strip()
+    if request.method == "POST":
+        if "path" in request.form:
+            path = (request.form.get("path") or "").strip()
+            raw_label = (request.form.get("device_label") or "").strip()
             # Glob expansion: support immediate children with .../*
-            if path.endswith('/*'):
+            if path.endswith("/*"):
                 base = os.path.normpath(os.path.expanduser(path[:-2]))
                 if not base or not os.path.isdir(base):
-                    flash('Base folder not found. Use a mounted path like /data/highlights', 'danger')
-                    return redirect(url_for('config.index'))
+                    flash(
+                        "Base folder not found. Use a mounted path like /data/highlights",
+                        "danger",
+                    )
+                    return redirect(url_for("config.index"))
                 added = 0
                 total = 0
-                for full in sorted(glob(os.path.join(base, '*'))):
+                for full in sorted(glob(os.path.join(base, "*"))):
                     if not os.path.isdir(full):
                         continue
                     total += 1
                     device_label = raw_label or os.path.basename(full)
-                    exists = SourcePath.query.filter_by(path=os.path.normpath(full)).first()
+                    exists = SourcePath.query.filter_by(
+                        path=os.path.normpath(full)
+                    ).first()
                     if exists:
                         continue
                     try:
-                        db.session.add(SourcePath(path=os.path.normpath(full), enabled=True, device_label=device_label))
+                        db.session.add(
+                            SourcePath(
+                                path=os.path.normpath(full),
+                                enabled=True,
+                                device_label=device_label,
+                            )
+                        )
                         db.session.commit()
                         added += 1
                     except IntegrityError:
                         db.session.rollback()
                         continue
                 if added:
-                    flash(f'Added {added} of {total} folder(s).', 'success')
+                    flash(f"Added {added} of {total} folder(s).", "success")
                 elif total == 0:
-                    flash('No subfolders found to add.', 'warning')
-                return redirect(url_for('config.index'))
+                    flash("No subfolders found to add.", "warning")
+                return redirect(url_for("config.index"))
 
             # Single path
-            path_norm = os.path.normpath(os.path.expanduser(path)) if path else ''
-            device_label = raw_label or (os.path.basename(path_norm) if path_norm else None)
+            path_norm = os.path.normpath(os.path.expanduser(path)) if path else ""
+            device_label = raw_label or (
+                os.path.basename(path_norm) if path_norm else None
+            )
             if not path_norm or not os.path.isdir(path_norm):
-                flash('Folder not found in container. Use a mounted path like /data/highlights/...', 'danger')
-                return redirect(url_for('config.index'))
+                flash(
+                    "Folder not found in container. Use a mounted path like /data/highlights/...",
+                    "danger",
+                )
+                return redirect(url_for("config.index"))
             existing = SourcePath.query.filter_by(path=path_norm).first()
             if existing:
                 if raw_label:
                     existing.device_label = raw_label
                     db.session.add(existing)
                     db.session.commit()
-                return redirect(url_for('config.index'))
+                return redirect(url_for("config.index"))
             try:
                 sp = SourcePath(path=path_norm, enabled=True, device_label=device_label)
                 db.session.add(sp)
                 db.session.commit()
-                flash('Source folder added.', 'success')
+                flash("Source folder added.", "success")
             except IntegrityError:
                 db.session.rollback()
-                flash('Folder already configured.', 'warning')
-            return redirect(url_for('config.index'))
+                flash("Folder already configured.", "warning")
+            return redirect(url_for("config.index"))
 
-        if 'ol_app_name' in request.form or 'ol_contact_email' in request.form:
-            cfg.ol_app_name = (request.form.get('ol_app_name') or '').strip() or None
-            cfg.ol_contact_email = (request.form.get('ol_contact_email') or '').strip() or None
+        if "ol_app_name" in request.form or "ol_contact_email" in request.form:
+            cfg.ol_app_name = (request.form.get("ol_app_name") or "").strip() or None
+            cfg.ol_contact_email = (
+                request.form.get("ol_contact_email") or ""
+            ).strip() or None
             db.session.add(cfg)
             db.session.commit()
-            return redirect(url_for('config.index'))
+            return redirect(url_for("config.index"))
 
-        if 'scan_schedule' in request.form:
-            new_schedule = (request.form.get('scan_schedule') or '').strip()
+        if "scan_schedule" in request.form:
+            new_schedule = (request.form.get("scan_schedule") or "").strip()
             if not new_schedule:
-                flash('Scan schedule cannot be empty', 'danger')
-                return redirect(url_for('config.index'))
+                flash("Scan schedule cannot be empty", "danger")
+                return redirect(url_for("config.index"))
 
             # Validate cron syntax
             try:
@@ -94,37 +112,49 @@ def index():
                 cfg.scan_schedule = new_schedule
                 db.session.add(cfg)
                 db.session.commit()
-                flash('Scan schedule updated successfully. Restart Celery Beat for changes to take effect.', 'success')
+                flash(
+                    "Scan schedule updated successfully. Restart Celery Beat for changes to take effect.",
+                    "success",
+                )
             except (ValueError, KeyError) as e:
-                flash(f'Invalid cron syntax: {str(e)}', 'danger')
-            return redirect(url_for('config.index'))
+                flash(f"Invalid cron syntax: {str(e)}", "danger")
+            return redirect(url_for("config.index"))
 
-        if 'job_retention_days' in request.form:
+        if "job_retention_days" in request.form:
             try:
-                retention_days = int(request.form.get('job_retention_days', 30))
+                retention_days = int(request.form.get("job_retention_days", 30))
                 if retention_days < 1 or retention_days > 365:
-                    flash('Retention days must be between 1 and 365', 'danger')
-                    return redirect(url_for('config.index'))
+                    flash("Retention days must be between 1 and 365", "danger")
+                    return redirect(url_for("config.index"))
                 cfg.job_retention_days = retention_days
                 db.session.add(cfg)
                 db.session.commit()
-                flash(f'Job retention policy updated: jobs older than {retention_days} days will be deleted automatically.', 'success')
+                flash(
+                    f"Job retention policy updated: jobs older than {retention_days} days will be deleted automatically.",
+                    "success",
+                )
             except ValueError:
-                flash('Invalid retention days value', 'danger')
-            return redirect(url_for('config.index'))
+                flash("Invalid retention days value", "danger")
+            return redirect(url_for("config.index"))
 
-    paths = SourcePath.query.order_by(SourcePath.enabled.desc(), SourcePath.path.asc()).all()
-    templates = ExportTemplate.query.order_by(ExportTemplate.is_default.desc(), ExportTemplate.name).all()
-    return render_template('config/index.html', paths=paths, cfg=cfg, templates=templates)
+    paths = SourcePath.query.order_by(
+        SourcePath.enabled.desc(), SourcePath.path.asc()
+    ).all()
+    templates = ExportTemplate.query.order_by(
+        ExportTemplate.is_default.desc(), ExportTemplate.name
+    ).all()
+    return render_template(
+        "config/index.html", paths=paths, cfg=cfg, templates=templates
+    )
 
 
-@bp.get('/config/suggest')
+@bp.get("/config/suggest")
 def suggest_paths():
     """Return directory suggestions for a given path prefix.
     Query params:
       - prefix: the partial path typed by the user
     """
-    prefix = (request.args.get('prefix') or '').strip()
+    prefix = (request.args.get("prefix") or "").strip()
     if not prefix:
         # Suggest common roots inside container
         candidates = ["/", "/data", "/data/highlights"]
@@ -136,14 +166,14 @@ def suggest_paths():
     # Decide base dir and needle
     if expanded.endswith(os.sep):
         base_dir = expanded
-        needle = ''
+        needle = ""
     else:
-        base_dir = os.path.dirname(expanded) or '/'
+        base_dir = os.path.dirname(expanded) or "/"
         needle = os.path.basename(expanded)
 
     results = []
     try:
-        for name in os.listdir(base_dir or '/'):  # base_dir may be ''
+        for name in os.listdir(base_dir or "/"):  # base_dir may be ''
             if needle and not name.startswith(needle):
                 continue
             full = os.path.join(base_dir, name)
@@ -161,61 +191,53 @@ def suggest_paths():
     return jsonify({"paths": sorted(results)})
 
 
-@bp.route('/config/paths/<int:pid>/toggle', methods=['POST'])
+@bp.route("/config/paths/<int:pid>/toggle", methods=["POST"])
 def toggle(pid: int):
     sp = SourcePath.query.get_or_404(pid)
     sp.enabled = not sp.enabled
     db.session.add(sp)
     db.session.commit()
     # No flash for enable/disable
-    return redirect(url_for('config.index'))
+    return redirect(url_for("config.index"))
 
 
-@bp.route('/config/paths/<int:pid>/delete', methods=['POST'])
+@bp.route("/config/paths/<int:pid>/delete", methods=["POST"])
 def delete(pid: int):
     sp = SourcePath.query.get_or_404(pid)
     db.session.delete(sp)
     db.session.commit()
-    return redirect(url_for('config.index'))
+    return redirect(url_for("config.index"))
 
 
-@bp.route('/config/paths/<int:pid>/label', methods=['POST'])
+@bp.route("/config/paths/<int:pid>/label", methods=["POST"])
 def update_label(pid: int):
     sp = SourcePath.query.get_or_404(pid)
-    raw_label = (request.form.get('device_label') or '').strip()
+    raw_label = (request.form.get("device_label") or "").strip()
     sp.device_label = raw_label or os.path.basename(os.path.normpath(sp.path))
     db.session.add(sp)
     db.session.commit()
-    return redirect(url_for('config.index'))
+    return redirect(url_for("config.index"))
 
 
-@bp.get('/config/validate-cron')
+@bp.get("/config/validate-cron")
 def validate_cron():
     """Validate a cron expression via AJAX."""
-    expression = request.args.get('expression', '').strip()
+    expression = request.args.get("expression", "").strip()
 
     if not expression:
-        return jsonify({
-            'valid': False,
-            'error': 'Cron expression cannot be empty'
-        })
+        return jsonify({"valid": False, "error": "Cron expression cannot be empty"})
 
     try:
         croniter(expression)
         # Get next 3 run times to show user
         from datetime import datetime
+
         iter_obj = croniter(expression, datetime.utcnow())
         next_runs = []
         for _ in range(3):
             next_run = iter_obj.get_next(datetime)
-            next_runs.append(next_run.strftime('%Y-%m-%d %H:%M:%S UTC'))
+            next_runs.append(next_run.strftime("%Y-%m-%d %H:%M:%S UTC"))
 
-        return jsonify({
-            'valid': True,
-            'next_runs': next_runs
-        })
+        return jsonify({"valid": True, "next_runs": next_runs})
     except (ValueError, KeyError) as e:
-        return jsonify({
-            'valid': False,
-            'error': f'Invalid cron syntax: {str(e)}'
-        })
+        return jsonify({"valid": False, "error": f"Invalid cron syntax: {str(e)}"})

--- a/app/views/config.py
+++ b/app/views/config.py
@@ -99,6 +99,20 @@ def index():
                 flash(f'Invalid cron syntax: {str(e)}', 'danger')
             return redirect(url_for('config.index'))
 
+        if 'job_retention_days' in request.form:
+            try:
+                retention_days = int(request.form.get('job_retention_days', 30))
+                if retention_days < 1 or retention_days > 365:
+                    flash('Retention days must be between 1 and 365', 'danger')
+                    return redirect(url_for('config.index'))
+                cfg.job_retention_days = retention_days
+                db.session.add(cfg)
+                db.session.commit()
+                flash(f'Job retention policy updated: jobs older than {retention_days} days will be deleted automatically.', 'success')
+            except ValueError:
+                flash('Invalid retention days value', 'danger')
+            return redirect(url_for('config.index'))
+
     paths = SourcePath.query.order_by(SourcePath.enabled.desc(), SourcePath.path.asc()).all()
     templates = ExportTemplate.query.order_by(ExportTemplate.is_default.desc(), ExportTemplate.name).all()
     return render_template('config/index.html', paths=paths, cfg=cfg, templates=templates)

--- a/app/views/exports.py
+++ b/app/views/exports.py
@@ -1,73 +1,106 @@
 import json
 import uuid
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, send_file
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    jsonify,
+    send_file,
+)
 from .. import db
 from ..models import ExportTemplate, ExportJob, Book, Highlight
 from celery_app import make_celery
 from flask import current_app
 
-bp = Blueprint('exports', __name__)
+bp = Blueprint("exports", __name__)
 
 
-@bp.route('/templates')
+@bp.route("/templates")
 def templates():
     """List all export templates"""
-    templates = ExportTemplate.query.order_by(ExportTemplate.is_default.desc(), ExportTemplate.name).all()
-    return render_template('exports/templates.html', templates=templates)
+    templates = ExportTemplate.query.order_by(
+        ExportTemplate.is_default.desc(), ExportTemplate.name
+    ).all()
+    return render_template("exports/templates.html", templates=templates)
 
 
-@bp.route('/templates/new', methods=['GET', 'POST'])
+@bp.route("/templates/new", methods=["GET", "POST"])
 def template_new():
     """Create new export template"""
-    if request.method == 'POST':
-        name = request.form.get('name', '').strip()
-        content = request.form.get('template_content', '').strip()
-        filename_template = request.form.get('filename_template', '').strip()
-        cover_filename_template = request.form.get('cover_filename_template', '').strip()
-        is_default = request.form.get('is_default') == 'on'
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        content = request.form.get("template_content", "").strip()
+        filename_template = request.form.get("filename_template", "").strip()
+        cover_filename_template = request.form.get(
+            "cover_filename_template", ""
+        ).strip()
+        is_default = request.form.get("is_default") == "on"
 
-        if not name or not content or not filename_template or not cover_filename_template:
-            flash('Template name, content, and filename templates are required.', 'danger')
-            return render_template('exports/template_edit.html', template=None)
+        if (
+            not name
+            or not content
+            or not filename_template
+            or not cover_filename_template
+        ):
+            flash(
+                "Template name, content, and filename templates are required.", "danger"
+            )
+            return render_template("exports/template_edit.html", template=None)
 
         # Unset other defaults if this is default
         if is_default:
-            ExportTemplate.query.filter_by(is_default=True).update({'is_default': False})
+            ExportTemplate.query.filter_by(is_default=True).update(
+                {"is_default": False}
+            )
 
         template = ExportTemplate(
             name=name,
             template_content=content,
             filename_template=filename_template,
             cover_filename_template=cover_filename_template,
-            is_default=is_default
+            is_default=is_default,
         )
         db.session.add(template)
         db.session.commit()
-        flash(f'Template "{name}" created successfully.', 'success')
-        return redirect(url_for('exports.templates'))
+        flash(f'Template "{name}" created successfully.', "success")
+        return redirect(url_for("exports.templates"))
 
-    return render_template('exports/template_edit.html', template=None)
+    return render_template("exports/template_edit.html", template=None)
 
 
-@bp.route('/templates/<int:template_id>/edit', methods=['GET', 'POST'])
+@bp.route("/templates/<int:template_id>/edit", methods=["GET", "POST"])
 def template_edit(template_id):
     """Edit existing export template"""
     template = ExportTemplate.query.get_or_404(template_id)
 
-    if request.method == 'POST':
-        name = request.form.get('name', '').strip()
-        content = request.form.get('template_content', '').strip()
-        filename_template = request.form.get('filename_template', '').strip()
-        cover_filename_template = request.form.get('cover_filename_template', '').strip()
-        is_default = request.form.get('is_default') == 'on'
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        content = request.form.get("template_content", "").strip()
+        filename_template = request.form.get("filename_template", "").strip()
+        cover_filename_template = request.form.get(
+            "cover_filename_template", ""
+        ).strip()
+        is_default = request.form.get("is_default") == "on"
 
-        if not name or not content or not filename_template or not cover_filename_template:
-            flash('Template name, content, and filename templates are required.', 'danger')
-            return render_template('exports/template_edit.html', template=template)
+        if (
+            not name
+            or not content
+            or not filename_template
+            or not cover_filename_template
+        ):
+            flash(
+                "Template name, content, and filename templates are required.", "danger"
+            )
+            return render_template("exports/template_edit.html", template=template)
 
         # Unset other defaults if this is default
         if is_default and not template.is_default:
-            ExportTemplate.query.filter_by(is_default=True).update({'is_default': False})
+            ExportTemplate.query.filter_by(is_default=True).update(
+                {"is_default": False}
+            )
 
         template.name = name
         template.template_content = content
@@ -75,40 +108,40 @@ def template_edit(template_id):
         template.cover_filename_template = cover_filename_template
         template.is_default = is_default
         db.session.commit()
-        flash(f'Template "{name}" updated successfully.', 'success')
-        return redirect(url_for('exports.templates'))
+        flash(f'Template "{name}" updated successfully.', "success")
+        return redirect(url_for("exports.templates"))
 
-    return render_template('exports/template_edit.html', template=template)
+    return render_template("exports/template_edit.html", template=template)
 
 
-@bp.route('/templates/<int:template_id>/delete', methods=['POST'])
+@bp.route("/templates/<int:template_id>/delete", methods=["POST"])
 def template_delete(template_id):
     """Delete export template"""
     template = ExportTemplate.query.get_or_404(template_id)
     name = template.name
     db.session.delete(template)
     db.session.commit()
-    flash(f'Template "{name}" deleted.', 'info')
-    return redirect(url_for('exports.templates'))
+    flash(f'Template "{name}" deleted.', "info")
+    return redirect(url_for("exports.templates"))
 
 
-@bp.route('/books/<int:book_id>/export', methods=['POST'])
+@bp.route("/books/<int:book_id>/export", methods=["POST"])
 def export_create(book_id):
     """Create export job for selected highlights"""
     book = Book.query.get_or_404(book_id)
-    highlight_ids = request.form.getlist('highlight_ids[]')
-    template_id = request.form.get('template_id', type=int)
+    highlight_ids = request.form.getlist("highlight_ids[]")
+    template_id = request.form.get("template_id", type=int)
 
     if not highlight_ids:
-        flash('Please select at least one highlight to export.', 'warning')
-        return redirect(url_for('books.detail', book_id=book_id))
+        flash("Please select at least one highlight to export.", "warning")
+        return redirect(url_for("books.detail", book_id=book_id))
 
     if not template_id:
         # Use default template
         template = ExportTemplate.query.filter_by(is_default=True).first()
         if not template:
-            flash('No export template configured. Please create one first.', 'danger')
-            return redirect(url_for('exports.templates'))
+            flash("No export template configured. Please create one first.", "danger")
+            return redirect(url_for("exports.templates"))
         template_id = template.id
 
     # Create job
@@ -118,7 +151,7 @@ def export_create(book_id):
         book_id=book_id,
         template_id=template_id,
         highlight_ids=json.dumps([int(h) for h in highlight_ids]),
-        status='pending'
+        status="pending",
     )
     db.session.add(job)
     db.session.commit()
@@ -126,40 +159,43 @@ def export_create(book_id):
     # Queue task
     app = current_app._get_current_object()
     celery = make_celery(app)
-    celery.send_task('tasks.export_highlights', args=[job_id])
+    celery.send_task("tasks.export_highlights", args=[job_id])
 
     # Redirect to unified jobs page
-    flash(f'Export job created successfully. Check the Jobs page for status.', 'success')
-    return redirect(url_for('jobs.index'))
+    flash(
+        f"Export job created successfully. Check the Jobs page for status.", "success"
+    )
+    return redirect(url_for("jobs.index"))
 
 
-@bp.route('/download/<job_id>')
+@bp.route("/download/<job_id>")
 def download(job_id):
     """Download completed export zip file"""
     job = ExportJob.query.filter_by(job_id=job_id).first_or_404()
 
-    if job.status != 'completed':
-        flash('Export is not ready yet.', 'warning')
-        return redirect(url_for('exports.job_status', job_id=job_id))
+    if job.status != "completed":
+        flash("Export is not ready yet.", "warning")
+        return redirect(url_for("exports.job_status", job_id=job_id))
 
     if not job.file_path:
-        flash('Export file not found.', 'danger')
-        return redirect(url_for('exports.job_status', job_id=job_id))
+        flash("Export file not found.", "danger")
+        return redirect(url_for("exports.job_status", job_id=job_id))
 
     from pathlib import Path
+
     zip_path = Path(job.file_path)
     if not zip_path.exists():
-        flash('Export file no longer exists.', 'danger')
-        return redirect(url_for('exports.job_status', job_id=job_id))
+        flash("Export file no longer exists.", "danger")
+        return redirect(url_for("exports.job_status", job_id=job_id))
 
     return send_file(
         zip_path,
         as_attachment=True,
-        download_name=f"highlights_export_{job.book.clean_title or job.book.raw_title}_{job_id[:8]}.zip"
+        download_name=f"highlights_export_{job.book.clean_title or job.book.raw_title}_{job_id[:8]}.zip",
     )
 
 
-@bp.route('/jobs/<job_id>/delete', methods=['POST'])
+@bp.route("/jobs/<job_id>/delete", methods=["POST"])
 def job_delete(job_id):
     """Delete a single export job and its file"""
     job = ExportJob.query.filter_by(job_id=job_id).first_or_404()
@@ -167,17 +203,18 @@ def job_delete(job_id):
     # Delete the file if it exists
     if job.file_path:
         from pathlib import Path
+
         zip_path = Path(job.file_path)
         if zip_path.exists():
             try:
                 zip_path.unlink()
             except Exception as e:
-                flash(f'Failed to delete export file: {e}', 'warning')
+                flash(f"Failed to delete export file: {e}", "warning")
 
     # Delete the job record
     book_title = job.book.clean_title or job.book.raw_title
     db.session.delete(job)
     db.session.commit()
 
-    flash(f'Export job for "{book_title}" deleted.', 'info')
-    return redirect(url_for('jobs.index'))
+    flash(f'Export job for "{book_title}" deleted.', "info")
+    return redirect(url_for("jobs.index"))

--- a/app/views/jobs.py
+++ b/app/views/jobs.py
@@ -1,12 +1,13 @@
-from flask import Blueprint, render_template, jsonify
+from flask import Blueprint, render_template, jsonify, redirect, url_for, flash
+from pathlib import Path
 from .. import db
 from ..models import Job, ExportJob
 from sqlalchemy import or_
 
-bp = Blueprint('jobs', __name__)
+bp = Blueprint("jobs", __name__)
 
 
-@bp.route('/jobs')
+@bp.route("/jobs")
 def index():
     """List all jobs (scans and exports) in one view"""
     # Get all Job records
@@ -19,60 +20,111 @@ def index():
     all_jobs = []
 
     for job in jobs:
-        all_jobs.append({
-            'id': job.job_id,
-            'type': job.job_type,
-            'status': job.status,
-            'created_at': job.created_at,
-            'completed_at': job.completed_at,
-            'error_message': job.error_message,
-            'result_summary': job.result_summary,
-            'is_export': False
-        })
+        all_jobs.append(
+            {
+                "id": job.job_id,
+                "type": job.job_type,
+                "status": job.status,
+                "created_at": job.created_at,
+                "completed_at": job.completed_at,
+                "error_message": job.error_message,
+                "result_summary": job.result_summary,
+                "is_export": False,
+            }
+        )
 
     for export_job in export_jobs:
-        all_jobs.append({
-            'id': export_job.job_id,
-            'type': 'export',
-            'status': export_job.status,
-            'created_at': export_job.created_at,
-            'completed_at': export_job.completed_at,
-            'error_message': export_job.error_message,
-            'book_title': export_job.book.clean_title or export_job.book.raw_title,
-            'file_path': export_job.file_path,
-            'is_export': True
-        })
+        all_jobs.append(
+            {
+                "id": export_job.job_id,
+                "type": "export",
+                "status": export_job.status,
+                "created_at": export_job.created_at,
+                "completed_at": export_job.completed_at,
+                "error_message": export_job.error_message,
+                "book_title": export_job.book.clean_title or export_job.book.raw_title,
+                "file_path": export_job.file_path,
+                "is_export": True,
+            }
+        )
 
     # Sort by creation time
-    all_jobs.sort(key=lambda x: x['created_at'], reverse=True)
+    all_jobs.sort(key=lambda x: x["created_at"], reverse=True)
 
-    return render_template('jobs/index.html', jobs=all_jobs[:100])
+    return render_template("jobs/index.html", jobs=all_jobs[:100])
 
 
-@bp.route('/jobs/<job_id>/status.json')
+@bp.route("/jobs/<job_id>/status.json")
 def job_status_json(job_id):
     """Get job status as JSON for polling"""
     # Check Job table first
     job = Job.query.filter_by(job_id=job_id).first()
     if job:
-        return jsonify({
-            'type': job.job_type,
-            'status': job.status,
-            'error_message': job.error_message,
-            'result_summary': job.result_summary,
-            'completed_at': job.completed_at.isoformat() if job.completed_at else None
-        })
+        return jsonify(
+            {
+                "type": job.job_type,
+                "status": job.status,
+                "error_message": job.error_message,
+                "result_summary": job.result_summary,
+                "completed_at": job.completed_at.isoformat()
+                if job.completed_at
+                else None,
+            }
+        )
 
     # Check ExportJob table
     export_job = ExportJob.query.filter_by(job_id=job_id).first()
     if export_job:
         from flask import url_for
-        return jsonify({
-            'type': 'export',
-            'status': export_job.status,
-            'error_message': export_job.error_message,
-            'completed_at': export_job.completed_at.isoformat() if export_job.completed_at else None,
-            'download_url': url_for('exports.download', job_id=job_id) if export_job.status == 'completed' else None
-        })
 
-    return jsonify({'error': 'Job not found'}), 404
+        return jsonify(
+            {
+                "type": "export",
+                "status": export_job.status,
+                "error_message": export_job.error_message,
+                "completed_at": export_job.completed_at.isoformat()
+                if export_job.completed_at
+                else None,
+                "download_url": url_for("exports.download", job_id=job_id)
+                if export_job.status == "completed"
+                else None,
+            }
+        )
+
+    return jsonify({"error": "Job not found"}), 404
+
+
+@bp.route("/jobs/clear-completed", methods=["POST"])
+def clear_completed():
+    """Delete all completed jobs (both scan and export jobs)"""
+    # Delete completed Job records (scan jobs)
+    completed_jobs = Job.query.filter_by(status="completed").all()
+    scan_jobs_deleted = len(completed_jobs)
+    for job in completed_jobs:
+        db.session.delete(job)
+
+    # Delete completed ExportJob records and their files
+    completed_export_jobs = ExportJob.query.filter_by(status="completed").all()
+    export_jobs_deleted = len(completed_export_jobs)
+    files_deleted = 0
+
+    for job in completed_export_jobs:
+        # Delete the export file if it exists
+        if job.file_path:
+            try:
+                file_path = Path(job.file_path)
+                if file_path.exists():
+                    file_path.unlink()
+                    files_deleted += 1
+            except Exception:
+                pass
+
+        db.session.delete(job)
+
+    db.session.commit()
+
+    flash(
+        f"Cleared {scan_jobs_deleted} scan job(s) and {export_jobs_deleted} export job(s)",
+        "success",
+    )
+    return redirect(url_for("jobs.index"))

--- a/app/views/tasks.py
+++ b/app/views/tasks.py
@@ -3,18 +3,19 @@ from flask import Blueprint, current_app, redirect, url_for, flash
 from ..models import SourcePath
 from celery_app import make_celery
 
-bp = Blueprint('tasks', __name__)
+bp = Blueprint("tasks", __name__)
 
 
-@bp.route('/tasks/scan')
+@bp.route("/tasks/scan")
 def trigger_scan():
     app = current_app._get_current_object()
     celery = make_celery(app)
     # Only enqueue if there are enabled source paths
     from .. import db  # ensure app context
+
     if SourcePath.query.filter_by(enabled=True).count() == 0:
-        flash('No source folders configured. Add folders in Config first.', 'warning')
-        return redirect(url_for('books.index'))
-    celery.send_task('tasks.scan_all_paths')
-    flash('Scan started in background.', 'info')
-    return redirect(url_for('books.index'))
+        flash("No source folders configured. Add folders in Config first.", "warning")
+        return redirect(url_for("books.index"))
+    celery.send_task("tasks.scan_all_paths")
+    flash("Scan started in background.", "info")
+    return redirect(url_for("books.index"))

--- a/celery_app.py
+++ b/celery_app.py
@@ -5,16 +5,17 @@ from celery import Celery
 def make_celery(flask_app):
     celery = Celery(
         flask_app.import_name,
-        broker=flask_app.config['CELERY_BROKER_URL'],
-        backend=flask_app.config.get('CELERY_RESULT_BACKEND', 'rpc://'),
-        include=['tasks']
+        broker=flask_app.config["CELERY_BROKER_URL"],
+        backend=flask_app.config.get("CELERY_RESULT_BACKEND", "rpc://"),
+        include=["tasks"],
     )
     celery.conf.update(task_ignore_result=True)
 
     # Configure Celery Beat schedule
     from celerybeat_schedule import get_beat_schedule
+
     celery.conf.beat_schedule = get_beat_schedule()
-    celery.conf.timezone = 'UTC'
+    celery.conf.timezone = "UTC"
 
     class ContextTask(celery.Task):
         def __call__(self, *args, **kwargs):
@@ -23,4 +24,3 @@ def make_celery(flask_app):
 
     celery.Task = ContextTask
     return celery
-

--- a/celerybeat_schedule.py
+++ b/celerybeat_schedule.py
@@ -4,6 +4,7 @@ Dynamic Celery Beat schedule configuration.
 This module provides the beat_schedule for Celery Beat based on the database configuration.
 The schedule is loaded from the AppConfig.scan_schedule field which uses cron syntax.
 """
+
 from celery.schedules import crontab
 from croniter import croniter
 
@@ -22,42 +23,44 @@ def get_beat_schedule():
 
     with flask_app.app_context():
         config = AppConfig.query.first()
-        cron_expression = config.scan_schedule if config and config.scan_schedule else '*/15 * * * *'
+        cron_expression = (
+            config.scan_schedule if config and config.scan_schedule else "*/15 * * * *"
+        )
 
         # Validate cron expression
         try:
             croniter(cron_expression)
         except (ValueError, KeyError):
             # Fallback to default if invalid
-            cron_expression = '*/15 * * * *'
+            cron_expression = "*/15 * * * *"
 
         # Parse cron expression (minute hour day month day_of_week)
         parts = cron_expression.split()
         if len(parts) != 5:
             # Fallback to default if invalid format
-            parts = ['*/15', '*', '*', '*', '*']
+            parts = ["*/15", "*", "*", "*", "*"]
 
         return {
-            'periodic-highlight-scan': {
-                'task': 'tasks.scan_all_paths',
-                'schedule': crontab(
+            "periodic-highlight-scan": {
+                "task": "tasks.scan_all_paths",
+                "schedule": crontab(
                     minute=parts[0],
                     hour=parts[1],
                     day_of_month=parts[2],
                     month_of_year=parts[3],
-                    day_of_week=parts[4]
+                    day_of_week=parts[4],
                 ),
-                'options': {
-                    'expires': 600  # Task expires after 10 minutes if not executed
-                }
+                "options": {
+                    "expires": 600  # Task expires after 10 minutes if not executed
+                },
             },
-            'daily-job-cleanup': {
-                'task': 'tasks.cleanup_old_jobs',
-                'schedule': crontab(minute='0', hour='0'),  # Run daily at midnight
-                'options': {
-                    'expires': 3600  # Task expires after 1 hour if not executed
-                }
-            }
+            "daily-job-cleanup": {
+                "task": "tasks.cleanup_old_jobs",
+                "schedule": crontab(minute="0", hour="0"),  # Run daily at midnight
+                "options": {
+                    "expires": 3600  # Task expires after 1 hour if not executed
+                },
+            },
         }
 
 

--- a/celerybeat_schedule.py
+++ b/celerybeat_schedule.py
@@ -50,6 +50,13 @@ def get_beat_schedule():
                 'options': {
                     'expires': 600  # Task expires after 10 minutes if not executed
                 }
+            },
+            'daily-job-cleanup': {
+                'task': 'tasks.cleanup_old_jobs',
+                'schedule': crontab(minute='0', hour='0'),  # Run daily at midnight
+                'options': {
+                    'expires': 3600  # Task expires after 1 hour if not executed
+                }
             }
         }
 

--- a/core/collector.py
+++ b/core/collector.py
@@ -11,4 +11,3 @@ def iter_metadata_files(base_path: Path) -> Iterator[Path]:
             continue
         for metadata_file in device_folder.rglob("metadata.*.lua"):
             yield metadata_file
-

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -4,11 +4,11 @@ from pydantic import BaseModel, model_validator
 
 
 class HighlightKind(str, Enum):
-    highlight = 'highlight'
-    highlight_empty = 'highlight_empty'
-    highlight_no_position = 'highlight_no_position'
-    bookmark = 'bookmark'
-    unknown = 'unknown'
+    highlight = "highlight"
+    highlight_empty = "highlight_empty"
+    highlight_no_position = "highlight_no_position"
+    bookmark = "bookmark"
+    unknown = "unknown"
 
 
 class ParserAnnotation(BaseModel):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,5 +73,19 @@ services:
       - rabbitmq
       - worker
 
+  flower:
+    build: .
+    command: ["celery", "-A", "tasks.celery", "flower", "--port=5555"]
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+psycopg://highlights:highlights@db:5432/highlights
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672//
+    ports:
+      - "5555:5555"
+    depends_on:
+      - rabbitmq
+      - worker
+
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       EXPORT_DIR: /data/exports
     volumes:
       - ./:/app
-      - ./sample-highlights:/data/highlights:ro
+      - ./highlights:/data/highlights:ro
       - ./exports:/data/exports
     depends_on:
       - db
@@ -66,7 +66,7 @@ services:
       EXPORT_DIR: /data/exports
     volumes:
       - ./:/app
-      - ./sample-highlights:/data/highlights:ro
+      - ./highlights:/data/highlights:ro
       - ./exports:/data/exports
     depends_on:
       - db

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,21 +9,24 @@ flowchart LR
   end
 
   subgraph App[Flask Application]
-    WEB[Flask Web<br/>books/config/exports views]
+    WEB[Flask Web<br/>books/config/jobs views]
     CORE[(core/ parser<br/>+ collector)]
   end
 
   subgraph Worker[Background]
     CELERY[Celery Worker<br/>scan & export tasks]
+    BEAT[Celery Beat<br/>scheduler]
+    FLOWER[Flower<br/>:5555 monitoring]
   end
 
-  DB[(Postgres<br/>Image Blobs)]
+  DB[(Postgres<br/>Jobs + Image Blobs)]
   MQ[(RabbitMQ)]
   FS[/Source Folders<br/>read-only/]
   EXPORTS[/Export Files<br/>ZIP archives/]
   OL[(Open Library API)]
 
   BROWSER -->|HTTP :48138| WEB
+  BROWSER -->|HTTP :5555| FLOWER
   WEB -->|SQL + serve images| DB
   WEB -->|AMQP enqueue| MQ
   CELERY -->|AMQP consume| MQ
@@ -34,74 +37,100 @@ flowchart LR
   WEB -->|HTTP fetch images| OL
   CELERY -->|write ZIP files| EXPORTS
   WEB -->|serve downloads| EXPORTS
+  BEAT -->|schedule periodic tasks| MQ
+  BEAT -->|read cron config| DB
+  FLOWER -->|monitor| MQ
+  FLOWER -->|view tasks| CELERY
 
   classDef store fill:#eef,stroke:#99c
   classDef ext fill:#ffe,stroke:#cc9
+  classDef monitor fill:#efe,stroke:#9c9
   class DB,MQ store
   class OL ext
+  class FLOWER monitor
 ```
 
 ## Components
 - Flask Web App: Serves pages to browse and edit metadata; no auth (LAN only).
 - Core Library (`core/`): Parsing/collection logic and pure utilities; easy to unit test.
-- Celery Worker: Background tasks to read KoReader metadata and populate DB.
-- Postgres: Primary persistence for cleaned data, relationships, and book cover images (stored as binary blobs).
+- Celery Worker: Background tasks to read KoReader metadata, populate DB, export highlights, and clean up old jobs.
+- Celery Beat: Scheduler for periodic tasks (scans, cleanup) using cron expressions from database config.
+- Flower: Web-based monitoring UI for Celery tasks, workers, and queues (accessible at :5555).
+- Postgres: Primary persistence for cleaned data, relationships, job records, and book cover images (stored as binary blobs).
 - RabbitMQ: Broker for Celery tasks.
 
 ## Data Flow
 + Source (read-only): KoReader metadata files (e.g., `metadata.*.lua`) under `HIGHLIGHTS_BASE_PATH`.
-+ Import: Celery scans paths → `core` parses → upsert into DB (no writes to source files).
++ Import: Celery scans paths → `core` parses → upsert into DB (no writes to source files). Scans can be triggered manually or run automatically on schedule via Celery Beat.
 + Manage: Flask UI edits cleaned fields (title, author, cover), searches Open Library and applies results, and merges highlights.
 + Images: Flask fetches cover images from external URLs (e.g., Open Library), stores them as binary blobs in Postgres (`image_data`, `image_content_type`), and serves them directly from the database.
-+ Export: User selects highlights → Flask creates ExportJob → Celery renders Jinja2 template → generates ZIP (markdown + cover) → stores in `EXPORT_DIR` → user downloads → optionally deletes job + file.
++ Export: User selects highlights → Flask creates ExportJob → Celery renders Jinja2 template with configurable filenames → generates ZIP (markdown + cover) → stores in `EXPORT_DIR` → user downloads → optionally deletes job + file.
++ Jobs: All background tasks (scans, exports) tracked in unified Job/ExportJob tables. Old jobs automatically cleaned up based on retention policy (default: 30 days).
++ Monitoring: Flower provides real-time monitoring of Celery tasks, workers, queues, and task history.
 
 ## Models (SQLAlchemy)
 - Book: id, raw_title, raw_authors, clean_title, clean_authors, external_url (stored in `goodreads_url`), image_url (deprecated), image_data (BYTEA blob), image_content_type, identifiers, language, created_at, updated_at.
-- Highlight: id, book_id, text, chapter, page_number, datetime, color, device_id, page_xpath, kind, created_at.
+- Highlight: id, book_id, text, chapter, page_number, datetime, color, device_id, page_xpath, kind, hidden (boolean), created_at.
 - HighlightDevice: id, highlight_id, device_id (unique per highlight).
 - Note: id, book_id, text, datetime, device_id, created_at.
 - Bookmark: id, book_id, chapter, page_number, datetime, device_id, created_at.
 - MergedHighlight: id, book_id, text, notes (optional), created_at.
 - MergedHighlightItem: merged_id, highlight_id (preserve originals; mark as merged via relation).
 - SourcePath: id, path, enabled, device_label.
-- AppConfig: id, ol_app_name, ol_contact_email, rustfs_url (deprecated, no longer used).
-- ExportTemplate: id, name, template_content (Jinja2), is_default, created_at, updated_at.
+- AppConfig: id, ol_app_name, ol_contact_email, scan_schedule (cron expression), job_retention_days (integer, default: 30).
+- ExportTemplate: id, name, template_content (Jinja2), filename_template (Jinja2), cover_filename_template (Jinja2), is_default, created_at, updated_at.
 - ExportJob: id, job_id (UUID), book_id, template_id, highlight_ids (JSON), status, error_message, file_path, completed_at, created_at, updated_at.
+- Job: id, job_id (task ID), job_type (scan/export), status (pending/processing/completed/failed), error_message, result_summary (JSON), completed_at, created_at.
 
 ## Flask Structure
 - app/
-  - __init__.py (factory + config)
+  - __init__.py (factory + config + Jinja filters: from_json, humandate, humandate_short)
   - views/
-    - books.py (list, detail, edit inline, OL search/apply, merge UI, refresh, image upload/fetch, cover serving)
+    - books.py (list, detail, edit inline, OL search/apply, merge UI, refresh, image upload/fetch, cover serving, hide/unhide highlights)
     - tasks.py (trigger rescan)
-    - config.py (manage folders + Open Library identity)
-    - exports.py (templates CRUD, export job creation, status polling, download, deletion)
+    - config.py (manage folders, Open Library identity, cron schedule validation, job retention policy)
+    - exports.py (templates CRUD, export job creation, download, deletion)
+    - jobs.py (unified jobs view showing all scan and export jobs)
   - services/
     - imagestore.py (fetch images from URLs)
     - openlibrary.py (API integration)
   - templates/
-    - layout.html, books/*.html, config/*.html, exports/*.html
+    - layout.html, books/*.html, config/*.html, exports/*.html, jobs/*.html
   - static/ (Bootstrap CSS/JS vendored or CDN, html2canvas.min.js)
 
 ## Celery
 - `celery_app.py` with factory using Flask config.
+- `celerybeat_schedule.py` with dynamic schedule loading from database.
 - Tasks:
-  - `scan_all_paths()`, `scan_base_path(path)`, `import_file(path)` - import highlights from KOReader metadata
-  - `export_highlights(job_id)` - render Jinja2 template with selected highlights, create ZIP with markdown + cover image
-  - `backfill_images()` - legacy task for image migration (deprecated)
-- Dedupe highlights per book by (text, page_number, kind in highlight variants) and attach device tags.
+  - `scan_all_paths()` - scan all enabled source paths, create Job record with statistics (files scanned, new books, new highlights)
+  - `scan_base_path(path)`, `import_file(path)` - import highlights from KOReader metadata
+  - `export_highlights(job_id)` - render Jinja2 template with selected highlights and configurable filenames, create ZIP with markdown + cover image
+  - `cleanup_old_jobs()` - delete Job and ExportJob records older than retention period, remove associated export files (scheduled daily at midnight)
+- Dedupe highlights per book by (book_id, text) across all highlight variants and attach device tags.
+- Scheduled tasks (via Celery Beat):
+  - Periodic scans: Configurable cron schedule from AppConfig.scan_schedule (default: */15 * * * *)
+  - Daily cleanup: Runs at midnight to remove old jobs based on AppConfig.job_retention_days (default: 30)
 
 ## Configuration
 - Env vars: `DATABASE_URL`, `HIGHLIGHTS_BASE_PATH`, `EXPORT_DIR`, `RABBITMQ_URL`, `FLASK_ENV`.
-- In-app config for source folders (with device labels) and Open Library App Name + Contact Email (used for User-Agent).
+- In-app config (AppConfig model):
+  - Source folders with device labels
+  - Open Library App Name + Contact Email (used for User-Agent)
+  - Periodic scan schedule (cron expression, default: */15 * * * *)
+  - Job retention policy (days, default: 30)
 - `.env` for local compose; secrets not committed.
-- Export templates stored in database (ExportTemplate model) with default Hugo blog template included.
+- Export templates stored in database (ExportTemplate model) with configurable filename templates for content and cover images.
 
 ## Non-goals
 - Do not modify any KoReader files or JSON outputs; DB is the system of record for cleaned/merged data.
 
 ## Deployment
 - Docker: multi-stage build generates `requirements.txt` from `pyproject.toml` via pip-compile, then installs with pip.
-- Port: web binds to 48138; exposed as `48138:48138` in compose.
-- Compose services: `db`, `rabbitmq`, `web`, `worker`.
+- Ports:
+  - Web: 48138 (Flask app)
+  - Flower: 5555 (Celery monitoring)
+  - RabbitMQ: 5672 (AMQP), 15672 (management UI)
+  - PostgreSQL: 5432
+- Compose services: `db`, `rabbitmq`, `web`, `worker`, `beat`, `flower`.
 - Images are stored as binary blobs (BYTEA) directly in PostgreSQL, eliminating the need for external image storage services.
+- Job records and export files managed automatically via retention policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "requests>=2.31",
   "Pillow>=10.0",
   "croniter>=2.0",
+  "flower>=2.0",
 ]
 
 [tool.uv]

--- a/scripts/add_job_retention_days.sql
+++ b/scripts/add_job_retention_days.sql
@@ -1,0 +1,10 @@
+-- Add job_retention_days column to app_config table
+ALTER TABLE app_config
+ADD COLUMN IF NOT EXISTS job_retention_days INTEGER NOT NULL DEFAULT 30;
+
+-- Update existing rows to have the default value
+UPDATE app_config
+SET job_retention_days = 30
+WHERE job_retention_days IS NULL;
+
+COMMENT ON COLUMN app_config.job_retention_days IS 'Number of days to retain job records. Jobs older than this will be automatically deleted (default: 30)';

--- a/scripts/fix_escaped_quotes.py
+++ b/scripts/fix_escaped_quotes.py
@@ -21,13 +21,13 @@ def unescape_lua_string(s: str) -> str:
     if not s:
         return s
     # Replace escape sequences in order from most specific to least
-    s = s.replace(r'\\', '\x00')  # Temporarily replace \\ with placeholder
-    s = s.replace(r'\"', '"')
+    s = s.replace(r"\\", "\x00")  # Temporarily replace \\ with placeholder
+    s = s.replace(r"\"", '"')
     s = s.replace(r"\'", "'")
-    s = s.replace(r'\n', '\n')
-    s = s.replace(r'\r', '\r')
-    s = s.replace(r'\t', '\t')
-    s = s.replace('\x00', '\\')  # Restore actual backslashes
+    s = s.replace(r"\n", "\n")
+    s = s.replace(r"\r", "\r")
+    s = s.replace(r"\t", "\t")
+    s = s.replace("\x00", "\\")  # Restore actual backslashes
     return s
 
 
@@ -38,10 +38,10 @@ def main():
 
         # Fix highlights
         highlights = Highlight.query.filter(
-            (Highlight.text.like('%\\\\"%')) |
-            (Highlight.text.like('%\\\\\'%')) |
-            (Highlight.text.like('%\\\\n%')) |
-            (Highlight.text.like('%\\\\t%'))
+            (Highlight.text.like('%\\\\"%'))
+            | (Highlight.text.like("%\\\\'%"))
+            | (Highlight.text.like("%\\\\n%"))
+            | (Highlight.text.like("%\\\\t%"))
         ).all()
 
         print(f"Found {len(highlights)} highlights with escape sequences")
@@ -50,14 +50,16 @@ def main():
             old_text = h.text
             h.text = unescape_lua_string(h.text)
             if h.text != old_text:
-                print(f"  Fixed highlight {h.id}: {old_text[:50]}... -> {h.text[:50]}...")
+                print(
+                    f"  Fixed highlight {h.id}: {old_text[:50]}... -> {h.text[:50]}..."
+                )
 
         # Fix notes
         notes = Note.query.filter(
-            (Note.text.like('%\\\\"%')) |
-            (Note.text.like('%\\\\\'%')) |
-            (Note.text.like('%\\\\n%')) |
-            (Note.text.like('%\\\\t%'))
+            (Note.text.like('%\\\\"%'))
+            | (Note.text.like("%\\\\'%"))
+            | (Note.text.like("%\\\\n%"))
+            | (Note.text.like("%\\\\t%"))
         ).all()
 
         print(f"Found {len(notes)} notes with escape sequences")
@@ -70,10 +72,10 @@ def main():
 
         # Fix book titles and authors
         books = Book.query.filter(
-            (Book.raw_title.like('%\\\\"%')) |
-            (Book.clean_title.like('%\\\\"%')) |
-            (Book.raw_authors.like('%\\\\"%')) |
-            (Book.clean_authors.like('%\\\\"%'))
+            (Book.raw_title.like('%\\\\"%'))
+            | (Book.clean_title.like('%\\\\"%'))
+            | (Book.raw_authors.like('%\\\\"%'))
+            | (Book.clean_authors.like('%\\\\"%'))
         ).all()
 
         print(f"Found {len(books)} books with escape sequences")
@@ -90,9 +92,11 @@ def main():
 
         # Commit all changes
         db.session.commit()
-        print(f"\nFixed {len(highlights)} highlights, {len(notes)} notes, and {len(books)} books")
+        print(
+            f"\nFixed {len(highlights)} highlights, {len(notes)} notes, and {len(books)} books"
+        )
         print("Migration complete!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/migrate_add_export_tables.py
+++ b/scripts/migrate_add_export_tables.py
@@ -9,13 +9,14 @@ def main():
     with app.app_context():
         # Create tables
         from app.models import ExportTemplate, ExportJob
+
         db.create_all()
 
         # Add default template
         default = ExportTemplate.query.filter_by(is_default=True).first()
         if not default:
             default_template = ExportTemplate(
-                name='Blog Post (Markdown)',
+                name="Blog Post (Markdown)",
                 is_default=True,
                 template_content="""---
 title: "Highlights from {{ book.clean_title or book.raw_title }}"
@@ -58,7 +59,7 @@ cover: cover.jpg
 {% endfor %}
 
 *Exported from KOllector on {{ current_timestamp }}*
-"""
+""",
             )
             db.session.add(default_template)
             db.session.commit()
@@ -67,5 +68,5 @@ cover: cover.jpg
             print(f"✓ Default template already exists: {default.name}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tasks.py
+++ b/tasks.py
@@ -7,7 +7,17 @@ from flask import current_app
 
 from celery_app import make_celery
 from app import create_app, db
-from app.models import Book, Highlight, Bookmark, Note, SourcePath, HighlightDevice, Job, ExportJob, AppConfig
+from app.models import (
+    Book,
+    Highlight,
+    Bookmark,
+    Note,
+    SourcePath,
+    HighlightDevice,
+    Job,
+    ExportJob,
+    AppConfig,
+)
 from core import LuaTableParser, iter_metadata_files, HighlightKind
 import json
 from datetime import datetime, timedelta
@@ -32,81 +42,96 @@ def _scan_base_path_internal(base: Path, device_label: Optional[str] = None) -> 
                 first = rel.parts[0] if rel.parts else None
             except Exception:
                 first = None
-            first_lower = (first or '').lower()
-            device_id = base.name if first_lower in {"storage", "internal", "sdcard"} else (first or base.name or 'unknown')
+            first_lower = (first or "").lower()
+            device_id = (
+                base.name
+                if first_lower in {"storage", "internal", "sdcard"}
+                else (first or base.name or "unknown")
+            )
         import_file(str(path), device_id=device_id)
         count += 1
     return count
 
 
-@celery.task(name='tasks.scan_base_path')
+@celery.task(name="tasks.scan_base_path")
 def scan_base_path(base_path: Optional[str] = None):
-    base = Path(base_path or current_app.config['HIGHLIGHTS_BASE_PATH'])
+    base = Path(base_path or current_app.config["HIGHLIGHTS_BASE_PATH"])
     count = _scan_base_path_internal(base)
     logger.info("Scanned %s files in %s", count, base)
     return count
 
 
-@celery.task(name='tasks.scan_all_paths', bind=True)
+@celery.task(name="tasks.scan_all_paths", bind=True)
 def scan_all_paths(self):
     task_id = self.request.id
 
     # Create job record
-    job = Job(
-        job_id=task_id,
-        job_type='scan',
-        status='processing'
-    )
+    job = Job(job_id=task_id, job_type="scan", status="processing")
     db.session.add(job)
     db.session.commit()
 
     try:
-        # Track statistics
+        # Track statistics - commit first to ensure clean counts
+        db.session.commit()
         books_before = Book.query.count()
         highlights_before = Highlight.query.count()
 
         total = 0
-        paths = SourcePath.query.filter_by(enabled=True).order_by(SourcePath.path.asc()).all()
+        paths = (
+            SourcePath.query.filter_by(enabled=True)
+            .order_by(SourcePath.path.asc())
+            .all()
+        )
         if paths:
             for sp in paths:
-                total += _scan_base_path_internal(Path(sp.path), device_label=sp.device_label if hasattr(sp, 'device_label') else None)
+                total += _scan_base_path_internal(
+                    Path(sp.path),
+                    device_label=sp.device_label
+                    if hasattr(sp, "device_label")
+                    else None,
+                )
         else:
             logger.info("No source paths configured; skipping scan.")
 
-        # Calculate new items
+        # Calculate new items - commit and get fresh counts
+        db.session.commit()
         books_after = Book.query.count()
         highlights_after = Highlight.query.count()
         new_books = books_after - books_before
         new_highlights = highlights_after - highlights_before
 
         logger.info("Scanned total %s files across configured paths", total)
-        logger.info("Added %s new book(s) and %s new highlight(s)", new_books, new_highlights)
+        logger.info(
+            "Added %s new book(s) and %s new highlight(s)", new_books, new_highlights
+        )
 
         # Update job record
-        job.status = 'completed'
-        job.result_summary = json.dumps({
-            'files_scanned': total,
-            'paths_count': len(paths) if paths else 0,
-            'new_books': new_books,
-            'new_highlights': new_highlights,
-            'total_books': books_after,
-            'total_highlights': highlights_after
-        })
+        job.status = "completed"
+        job.result_summary = json.dumps(
+            {
+                "files_scanned": total,
+                "paths_count": len(paths) if paths else 0,
+                "new_books": new_books,
+                "new_highlights": new_highlights,
+                "total_books": books_after,
+                "total_highlights": highlights_after,
+            }
+        )
         job.completed_at = datetime.utcnow()
         db.session.commit()
 
         return total
     except Exception as e:
         logger.exception("Scan failed: %s", e)
-        job.status = 'failed'
+        job.status = "failed"
         job.error_message = str(e)
         job.completed_at = datetime.utcnow()
         db.session.commit()
         raise
 
 
-@celery.task(name='tasks.import_file')
-def import_file(path: str, device_id: str = 'unknown'):
+@celery.task(name="tasks.import_file")
+def import_file(path: str, device_id: str = "unknown"):
     p = Path(path)
     try:
         parsed = LuaTableParser.parse_file(p)
@@ -121,10 +146,16 @@ def import_file(path: str, device_id: str = 'unknown'):
     # Upsert book
     # Derive normalized title key for fallback grouping
     parent_name = p.parent.name
-    folder_title = parent_name[:-4] if parent_name.lower().endswith('.sdr') else parent_name
-    folder_title = folder_title.replace('_', ' ').strip()
-    title_candidate = (parsed.doc_props.title if (parsed.doc_props and parsed.doc_props.title) else folder_title) or None
-    norm_title = re.sub(r"\s+", " ", (title_candidate or '')).strip().lower() or None
+    folder_title = (
+        parent_name[:-4] if parent_name.lower().endswith(".sdr") else parent_name
+    )
+    folder_title = folder_title.replace("_", " ").strip()
+    title_candidate = (
+        parsed.doc_props.title
+        if (parsed.doc_props and parsed.doc_props.title)
+        else folder_title
+    ) or None
+    norm_title = re.sub(r"\s+", " ", (title_candidate or "")).strip().lower() or None
 
     book = None
     if checksum:
@@ -132,13 +163,19 @@ def import_file(path: str, device_id: str = 'unknown'):
         if not book and norm_title:
             # attempt to find by normalized title across existing books
             from sqlalchemy import func
-            book = Book.query.filter(func.lower(Book.clean_title) == norm_title).first() or \
-                   Book.query.filter(func.lower(Book.raw_title) == norm_title).first()
+
+            book = (
+                Book.query.filter(func.lower(Book.clean_title) == norm_title).first()
+                or Book.query.filter(func.lower(Book.raw_title) == norm_title).first()
+            )
     else:
         if norm_title:
             from sqlalchemy import func
-            book = Book.query.filter(func.lower(Book.clean_title) == norm_title).first() or \
-                   Book.query.filter(func.lower(Book.raw_title) == norm_title).first()
+
+            book = (
+                Book.query.filter(func.lower(Book.clean_title) == norm_title).first()
+                or Book.query.filter(func.lower(Book.raw_title) == norm_title).first()
+            )
 
     if not book:
         # Build a stable key of max 64 chars when checksum missing
@@ -146,9 +183,11 @@ def import_file(path: str, device_id: str = 'unknown'):
             key = checksum
         else:
             base = norm_title or str(p)
-            key = hashlib.sha256(base.encode('utf-8', errors='ignore')).hexdigest()  # 64 hex chars
+            key = hashlib.sha256(
+                base.encode("utf-8", errors="ignore")
+            ).hexdigest()  # 64 hex chars
         book = Book(checksum=key)
-    if not getattr(book, 'raw_title', None):
+    if not getattr(book, "raw_title", None):
         book.raw_title = title_candidate
 
     if doc_props:
@@ -158,7 +197,7 @@ def import_file(path: str, device_id: str = 'unknown'):
         book.description = doc_props.description or book.description
 
     # Seed clean_title from candidate if empty
-    if not getattr(book, 'clean_title', None):
+    if not getattr(book, "clean_title", None):
         book.clean_title = title_candidate
     book.file_path = parsed.doc_path or book.file_path
     db.session.add(book)
@@ -172,26 +211,40 @@ def import_file(path: str, device_id: str = 'unknown'):
             # treat as Note if textual bookmark
             note = Note(
                 book_id=book.id,
-                text=ann.text or '',
-                datetime=ann.datetime or '',
+                text=ann.text or "",
+                datetime=ann.datetime or "",
                 device_id=device_id,
             )
             db.session.add(note)
             imported += 1
             continue
 
-        if kind in {HighlightKind.highlight, HighlightKind.highlight_empty, HighlightKind.highlight_no_position}:
+        if kind in {
+            HighlightKind.highlight,
+            HighlightKind.highlight_empty,
+            HighlightKind.highlight_no_position,
+        }:
             # Deduplicate by content within a book (ignore exact kind and page number)
             # Page numbers can differ across devices/editions, so we dedupe by text only
             existing = Highlight.query.filter(
                 Highlight.book_id == book.id,
-                Highlight.text == (ann.text or ''),
-                Highlight.kind.in_(['highlight', 'highlight_empty', 'highlight_no_position'])
+                Highlight.text == (ann.text or ""),
+                Highlight.kind.in_(
+                    ["highlight", "highlight_empty", "highlight_no_position"]
+                ),
             ).first()
             if existing:
                 # attach device tag if missing
-                if device_id and not any(d.device_id == device_id for d in existing.devices):
-                    db.session.add(HighlightDevice(highlight_id=existing.id, device_id=device_id))
+                if device_id:
+                    existing_device = HighlightDevice.query.filter_by(
+                        highlight_id=existing.id, device_id=device_id
+                    ).first()
+                    if not existing_device:
+                        db.session.add(
+                            HighlightDevice(
+                                highlight_id=existing.id, device_id=device_id
+                            )
+                        )
                 # Optionally update missing fields (chapter/datetime/page_xpath/color)
                 if not existing.chapter and ann.chapter:
                     existing.chapter = ann.chapter
@@ -209,31 +262,37 @@ def import_file(path: str, device_id: str = 'unknown'):
             else:
                 h = Highlight(
                     book_id=book.id,
-                    text=ann.text or '',
-                    chapter=ann.chapter or '',
+                    text=ann.text or "",
+                    chapter=ann.chapter or "",
                     page_number=ann.pageno or 0,
-                    datetime=ann.datetime or '',
-                    color=ann.color or '',
-                    drawer=ann.drawer or '',
+                    datetime=ann.datetime or "",
+                    color=ann.color or "",
+                    drawer=ann.drawer or "",
                     device_id=device_id,
-                    page_xpath=ann.page or '',
+                    page_xpath=ann.page or "",
                     kind=kind.value,
                 )
                 db.session.add(h)
                 db.session.flush()
                 if device_id:
-                    db.session.add(HighlightDevice(highlight_id=h.id, device_id=device_id))
+                    db.session.add(
+                        HighlightDevice(highlight_id=h.id, device_id=device_id)
+                    )
                 imported += 1
         elif kind == HighlightKind.unknown:
             # ignore
             pass
 
     db.session.commit()
-    logger.info("Imported %s annotations for %s", imported, book.raw_title or book.clean_title or book.id)
+    logger.info(
+        "Imported %s annotations for %s",
+        imported,
+        book.raw_title or book.clean_title or book.id,
+    )
     return imported
 
 
-@celery.task(name='tasks.export_highlights')
+@celery.task(name="tasks.export_highlights")
 def export_highlights(job_id: str):
     """Render highlights export using Jinja template and create zip file.
 
@@ -253,32 +312,36 @@ def export_highlights(job_id: str):
         return
 
     try:
-        job.status = 'processing'
+        job.status = "processing"
         db.session.commit()
 
         # Load data
         book = Book.query.get(job.book_id)
         template = ExportTemplate.query.get(job.template_id)
         highlight_ids = json.loads(job.highlight_ids)
-        highlights = Highlight.query.filter(Highlight.id.in_(highlight_ids)).order_by(Highlight.page_number, Highlight.datetime).all()
+        highlights = (
+            Highlight.query.filter(Highlight.id.in_(highlight_ids))
+            .order_by(Highlight.page_number, Highlight.datetime)
+            .all()
+        )
 
         # Calculate read range
         dates = [h.datetime for h in highlights if h.datetime]
-        read_start = min(dates).split(' ')[0] if dates else None
-        read_end = max(dates).split(' ')[0] if dates else None
+        read_start = min(dates).split(" ")[0] if dates else None
+        read_end = max(dates).split(" ")[0] if dates else None
 
         # Prepare template context
-        export_date = datetime.now().strftime('%Y-%m-%d')
+        export_date = datetime.now().strftime("%Y-%m-%d")
         template_context = {
-            'book': book,
-            'highlights': highlights,
-            'read_start': read_start,
-            'read_end': read_end,
-            'current_date': export_date,
-            'current_timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            'book_title': book.clean_title or book.raw_title or 'book',
-            'book_authors': book.clean_authors or book.raw_authors or '',
-            'export_date': export_date
+            "book": book,
+            "highlights": highlights,
+            "read_start": read_start,
+            "read_end": read_end,
+            "current_date": export_date,
+            "current_timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "book_title": book.clean_title or book.raw_title or "book",
+            "book_authors": book.clean_authors or book.raw_authors or "",
+            "export_date": export_date,
         }
 
         # Render content template
@@ -289,9 +352,9 @@ def export_highlights(job_id: str):
         def sanitize_filename(name: str) -> str:
             """Sanitize a filename by removing invalid characters."""
             # Remove invalid characters
-            safe = re.sub(r'[^\w\s.-]', '', name)
+            safe = re.sub(r"[^\w\s.-]", "", name)
             # Collapse whitespace and hyphens
-            safe = re.sub(r'[-\s]+', '_', safe).strip('_')
+            safe = re.sub(r"[-\s]+", "_", safe).strip("_")
             # Limit length
             return safe[:200]
 
@@ -304,39 +367,44 @@ def export_highlights(job_id: str):
         safe_cover_filename = sanitize_filename(rendered_cover_filename)
 
         # Create zip file
-        exports_dir = Path(current_app.config.get('EXPORT_DIR', '/tmp/exports'))
+        exports_dir = Path(current_app.config.get("EXPORT_DIR", "/tmp/exports"))
         exports_dir.mkdir(parents=True, exist_ok=True)
 
         zip_path = exports_dir / f"export_{job_id}.zip"
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             # Add rendered content
             zf.writestr(safe_filename, rendered)
 
             # Add book cover if available
             if book.image_data:
-                ext = 'jpg' if book.image_content_type == 'image/jpeg' else 'png'
-                zf.writestr(f'{safe_cover_filename}.{ext}', book.image_data)
+                ext = "jpg" if book.image_content_type == "image/jpeg" else "png"
+                zf.writestr(f"{safe_cover_filename}.{ext}", book.image_data)
 
-        job.status = 'completed'
+        job.status = "completed"
         job.file_path = str(zip_path)
         job.completed_at = datetime.utcnow()
         db.session.commit()
 
-        logger.info("Completed export job %s: %s highlights from '%s'",
-                   job_id, len(highlights), book.clean_title or book.raw_title)
+        logger.info(
+            "Completed export job %s: %s highlights from '%s'",
+            job_id,
+            len(highlights),
+            book.clean_title or book.raw_title,
+        )
 
     except Exception as e:
         logger.exception("Failed export job %s: %s", job_id, e)
-        job.status = 'failed'
+        job.status = "failed"
         job.error_message = str(e)
         db.session.commit()
 
 
-@celery.task(name='tasks.cleanup_old_jobs')
+@celery.task(name="tasks.cleanup_old_jobs")
 def cleanup_old_jobs():
     """Delete old jobs and their associated files based on retention policy.
 
     Runs daily at midnight to clean up:
+    - Empty scan jobs (no new books/highlights) older than 4x the scan interval
     - Job records older than retention_days
     - ExportJob records older than retention_days
     - Associated export zip files
@@ -344,10 +412,50 @@ def cleanup_old_jobs():
     # Get retention policy from config
     cfg = AppConfig.query.first()
     retention_days = cfg.job_retention_days if cfg else 30
+    scan_schedule = cfg.scan_schedule if cfg and cfg.scan_schedule else "*/15 * * * *"
 
+    # Calculate scan interval in minutes
+    from croniter import croniter
+    from datetime import datetime as dt
+
+    try:
+        cron = croniter(scan_schedule, dt.utcnow())
+        next_run = cron.get_next(dt)
+        scan_interval_minutes = (next_run - dt.utcnow()).total_seconds() / 60
+    except Exception:
+        # Default to 15 minutes if cron parsing fails
+        scan_interval_minutes = 15
+
+    # Calculate cutoff for empty scans (4x the scan interval)
+    empty_scan_cutoff_minutes = scan_interval_minutes * 4
+    empty_scan_cutoff_date = datetime.utcnow() - timedelta(
+        minutes=empty_scan_cutoff_minutes
+    )
+
+    # Clean up empty scan jobs (where nothing was added)
+    empty_scan_jobs = Job.query.filter(
+        Job.job_type == "scan",
+        Job.created_at < empty_scan_cutoff_date,
+        Job.status == "completed",
+    ).all()
+
+    empty_jobs_deleted = 0
+    for job in empty_scan_jobs:
+        # Check if this scan added nothing
+        if job.result_summary:
+            try:
+                result = json.loads(job.result_summary)
+                if (
+                    result.get("new_books", 0) == 0
+                    and result.get("new_highlights", 0) == 0
+                ):
+                    db.session.delete(job)
+                    empty_jobs_deleted += 1
+            except Exception:
+                pass
+
+    # Clean up regular Job records (scan jobs) older than retention_days
     cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
-
-    # Clean up Job records (scan jobs)
     old_jobs = Job.query.filter(Job.created_at < cutoff_date).all()
     jobs_deleted = len(old_jobs)
     for job in old_jobs:
@@ -374,13 +482,20 @@ def cleanup_old_jobs():
     db.session.commit()
 
     logger.info(
-        "Cleanup completed: deleted %d Job record(s), %d ExportJob record(s), and %d export file(s) older than %d days",
-        jobs_deleted, export_jobs_deleted, files_deleted, retention_days
+        "Cleanup completed: deleted %d empty scan job(s) (older than %.1f minutes), %d Job record(s) (older than %d days), %d ExportJob record(s), and %d export file(s)",
+        empty_jobs_deleted,
+        empty_scan_cutoff_minutes,
+        jobs_deleted,
+        retention_days,
+        export_jobs_deleted,
+        files_deleted,
     )
 
     return {
-        'jobs_deleted': jobs_deleted,
-        'export_jobs_deleted': export_jobs_deleted,
-        'files_deleted': files_deleted,
-        'retention_days': retention_days
+        "empty_jobs_deleted": empty_jobs_deleted,
+        "empty_scan_cutoff_minutes": empty_scan_cutoff_minutes,
+        "jobs_deleted": jobs_deleted,
+        "export_jobs_deleted": export_jobs_deleted,
+        "files_deleted": files_deleted,
+        "retention_days": retention_days,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,3 @@ if str(ROOT) not in sys.path:
 # Use a lightweight SQLite DB during tests
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("HIGHLIGHTS_BASE_PATH", str(ROOT / "sample-highlights"))
-

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ from app import create_app
 def test_index_route_renders():
     app = create_app()
     client = app.test_client()
-    resp = client.get('/')
+    resp = client.get("/")
     assert resp.status_code == 200
     # Smoke check: landing should render and include CTA buttons
-    assert b'Configure Sources' in resp.data or b'Browse Books' in resp.data
+    assert b"Configure Sources" in resp.data or b"Browse Books" in resp.data

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -4,8 +4,7 @@ from core.collector import iter_metadata_files
 
 
 def test_iter_metadata_files_finds_samples():
-    base = Path('sample-highlights')
+    base = Path("sample-highlights")
     files = list(iter_metadata_files(base))
     assert files, "Expected iter_metadata_files to find sample metadata files"
-    assert all(f.name.startswith('metadata.') and f.suffix == '.lua' for f in files)
-
+    assert all(f.name.startswith("metadata.") and f.suffix == ".lua" for f in files)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,8 +8,8 @@ from core.schemas import ParsedFile, HighlightKind
 
 
 def test_parse_file_structure_from_sample():
-    sample_root = Path('sample-highlights')
-    files = list(sample_root.rglob('metadata.*.lua'))
+    sample_root = Path("sample-highlights")
+    files = list(sample_root.rglob("metadata.*.lua"))
     assert files, "Expected at least one metadata.*.lua under sample-highlights"
 
     data = LuaTableParser.parse_file(files[0])
@@ -21,19 +21,19 @@ def test_parse_file_structure_from_sample():
     # Don't assert exact values to keep the test robust
     if data.doc_props:
         # Some samples may lack authors; require at least title when present
-        assert hasattr(data.doc_props, 'title')
+        assert hasattr(data.doc_props, "title")
 
 
 def test_annotations_fields_present_when_available():
-    sample_root = Path('sample-highlights')
-    files = list(sample_root.rglob('metadata.*.lua'))
+    sample_root = Path("sample-highlights")
+    files = list(sample_root.rglob("metadata.*.lua"))
     data = LuaTableParser.parse_file(files[0])
     annotations = data.annotations or []
     # If annotations exist, they should be dict-like entries parsed from Lua
     if annotations:
         a0 = annotations[0]
         # Not all fields are mandatory, but if present must be correct type
-        for key in ['chapter', 'color', 'datetime', 'page', 'text', 'drawer']:
+        for key in ["chapter", "color", "datetime", "page", "text", "drawer"]:
             if getattr(a0, key, None) is not None:
                 assert isinstance(getattr(a0, key), str)
         assert isinstance(a0.kind, HighlightKind)

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,19 @@ toml = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481, upload-time = "2024-12-17T17:17:47.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", size = 25468, upload-time = "2024-12-17T17:17:45.359Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -362,6 +375,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/53/b0a9fcc1b1297f51e68b69ed3b7c3c40d8c45be1391d77ae198712914392/flask_sqlalchemy-3.1.1.tar.gz", hash = "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312", size = 81899, upload-time = "2023-09-11T21:42:36.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl", hash = "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0", size = 25125, upload-time = "2023-09-11T21:42:34.514Z" },
+]
+
+[[package]]
+name = "flower"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "celery" },
+    { name = "humanize" },
+    { name = "prometheus-client" },
+    { name = "pytz" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a1/357f1b5d8946deafdcfdd604f51baae9de10aafa2908d0b7322597155f92/flower-2.0.1.tar.gz", hash = "sha256:5ab717b979530770c16afb48b50d2a98d23c3e9fe39851dcf6bc4d01845a02a0", size = 3220408, upload-time = "2023-08-13T14:37:46.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/ff/ee2f67c0ff146ec98b5df1df637b2bc2d17beeb05df9f427a67bd7a7d79c/flower-2.0.1-py2.py3-none-any.whl", hash = "sha256:9db2c621eeefbc844c8dd88be64aef61e84e2deb29b271e02ab2b5b9f01068e2", size = 383553, upload-time = "2023-08-13T14:37:41.552Z" },
 ]
 
 [[package]]
@@ -432,6 +461,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/43/50033d25ad96a7f3845f40999b4778f753c3901a11808a584fed7c00d9f5/humanize-4.14.0.tar.gz", hash = "sha256:2fa092705ea640d605c435b1ca82b2866a1b601cdf96f076d70b79a855eba90d", size = 82939, upload-time = "2025-10-15T13:04:51.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/5b/9512c5fb6c8218332b530f13500c6ff5f3ce3342f35e0dd7be9ac3856fd3/humanize-4.14.0-py3-none-any.whl", hash = "sha256:d57701248d040ad456092820e6fde56c930f17749956ac47f4f655c0c547bfff", size = 132092, upload-time = "2025-10-15T13:04:49.404Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -476,8 +514,10 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "celery" },
+    { name = "croniter" },
     { name = "flask" },
     { name = "flask-sqlalchemy" },
+    { name = "flower" },
     { name = "gunicorn" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
@@ -495,8 +535,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=5.3" },
+    { name = "croniter", specifier = ">=2.0" },
     { name = "flask", specifier = ">=2.3" },
     { name = "flask-sqlalchemy", specifier = ">=3.1" },
+    { name = "flower", specifier = ">=2.0" },
     { name = "gunicorn", specifier = ">=21.2" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
@@ -725,6 +767,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
 ]
 
 [[package]]
@@ -1006,6 +1057,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1121,6 +1181,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/ce/1eb500eae19f4648281bb2186927bb062d2438c2e5093d1360391afd2f90/tornado-6.5.2.tar.gz", hash = "sha256:ab53c8f9a0fa351e2c0741284e06c7a45da86afb544133201c5cc8578eb076a0", size = 510821, upload-time = "2025-08-08T18:27:00.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/48/6a7529df2c9cc12efd2e8f5dd219516184d703b34c06786809670df5b3bd/tornado-6.5.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2436822940d37cde62771cff8774f4f00b3c8024fe482e16ca8387b8a2724db6", size = 442563, upload-time = "2025-08-08T18:26:42.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b5/9b575a0ed3e50b00c40b08cbce82eb618229091d09f6d14bce80fc01cb0b/tornado-6.5.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:583a52c7aa94ee046854ba81d9ebb6c81ec0fd30386d96f7640c96dad45a03ef", size = 440729, upload-time = "2025-08-08T18:26:44.473Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4e/619174f52b120efcf23633c817fd3fed867c30bff785e2cd5a53a70e483c/tornado-6.5.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0fe179f28d597deab2842b86ed4060deec7388f1fd9c1b4a41adf8af058907e", size = 444295, upload-time = "2025-08-08T18:26:46.021Z" },
+    { url = "https://files.pythonhosted.org/packages/95/fa/87b41709552bbd393c85dd18e4e3499dcd8983f66e7972926db8d96aa065/tornado-6.5.2-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b186e85d1e3536d69583d2298423744740986018e393d0321df7340e71898882", size = 443644, upload-time = "2025-08-08T18:26:47.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/41/fb15f06e33d7430ca89420283a8762a4e6b8025b800ea51796ab5e6d9559/tornado-6.5.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e792706668c87709709c18b353da1f7662317b563ff69f00bab83595940c7108", size = 443878, upload-time = "2025-08-08T18:26:50.599Z" },
+    { url = "https://files.pythonhosted.org/packages/11/92/fe6d57da897776ad2e01e279170ea8ae726755b045fe5ac73b75357a5a3f/tornado-6.5.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:06ceb1300fd70cb20e43b1ad8aaee0266e69e7ced38fa910ad2e03285009ce7c", size = 444549, upload-time = "2025-08-08T18:26:51.864Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/02/c8f4f6c9204526daf3d760f4aa555a7a33ad0e60843eac025ccfd6ff4a93/tornado-6.5.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:74db443e0f5251be86cbf37929f84d8c20c27a355dd452a5cfa2aada0d001ec4", size = 443973, upload-time = "2025-08-08T18:26:53.625Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/2d/f5f5707b655ce2317190183868cd0f6822a1121b4baeae509ceb9590d0bd/tornado-6.5.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b5e735ab2889d7ed33b32a459cac490eda71a1ba6857b0118de476ab6c366c04", size = 443954, upload-time = "2025-08-08T18:26:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/59/593bd0f40f7355806bf6573b47b8c22f8e1374c9b6fd03114bd6b7a3dcfd/tornado-6.5.2-cp39-abi3-win32.whl", hash = "sha256:c6f29e94d9b37a95013bb669616352ddb82e3bfe8326fccee50583caebc8a5f0", size = 445023, upload-time = "2025-08-08T18:26:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2a/f609b420c2f564a748a2d80ebfb2ee02a73ca80223af712fca591386cafb/tornado-6.5.2-cp39-abi3-win_amd64.whl", hash = "sha256:e56a5af51cc30dd2cae649429af65ca2f6571da29504a07995175df14c18f35f", size = 445427, upload-time = "2025-08-08T18:26:57.91Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4f/e1f65e8f8c76d73658b33d33b81eed4322fb5085350e4328d5c956f0c8f9/tornado-6.5.2-cp39-abi3-win_arm64.whl", hash = "sha256:d6c33dc3672e3a1f3618eb63b7ef4683a7688e7b9e6e8f0d9aa5726360a004af", size = 444456, upload-time = "2025-08-08T18:26:59.207Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

This PR adds automatic job retention and Celery monitoring via Flower.

## Features

### 🗑️ Job Retention Policy
- Configurable retention period (1-365 days, default: 30)
- Automatic daily cleanup at midnight via Celery Beat
- Deletes old Job and ExportJob records
- Automatically removes associated export zip files
- Configuration field added to Config page

### 🌸 Flower Monitoring
- Added Flower service for Celery task monitoring
- Real-time task monitoring UI at http://localhost:5555
- View active/scheduled/completed tasks
- Monitor worker status and performance
- View task arguments, results, and tracebacks

## Implementation

### Job Retention
- New `job_retention_days` column in AppConfig (default: 30)
- `cleanup_old_jobs` task scheduled daily at midnight
- Cleanup removes records older than retention period
- Export files deleted before database records

### Flower Service
- New docker-compose service
- Connects to RabbitMQ broker
- Port 5555 exposed for web UI
- Added flower>=2.0 dependency

## UI Changes
- Job Retention section added to Config page
- Moved below Open Library config
- Compact input field (180px) with days label
- Clear, concise text and button labels

## Database Changes
- New column: `app_config.job_retention_days` (INTEGER, default: 30)
- Migration script: `scripts/add_job_retention_days.sql`

## New Dependencies
- `flower>=2.0` - Celery monitoring tool

## Usage

### Configure Retention
1. Go to Config page
2. Set retention days (1-365)
3. Click "Save"
4. Old jobs will be cleaned up automatically at midnight

### Access Flower
- Navigate to http://localhost:5555
- View all Celery tasks and workers
- Monitor task execution in real-time

## Testing
- ✅ Job retention configuration saves correctly
- ✅ Cleanup task deletes old jobs and files
- ✅ Flower UI accessible and displays tasks
- ✅ UI layout responsive on mobile